### PR TITLE
Replace constant DOM polling by using mutationObserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 output/*
 certificates/*
 *.pyc
+/.project

--- a/src/common/main.js
+++ b/src/common/main.js
@@ -21,6 +21,9 @@ function injectScript(path) {
   document.getElementsByTagName('body')[0].appendChild(script);
 }
 
+/* Load this to setup behaviors when the DOM updates */
+injectScript('res/features/init/actOnChange.js');
+
 function ensureDefaultsAreSet() {
   var storedKeys = kango.storage.getKeys();
 

--- a/src/common/res/features/check-credit-balances/main.js
+++ b/src/common/res/features/check-credit-balances/main.js
@@ -1,47 +1,58 @@
-(function checkCreditBalances_enhancedYNAB() { // give function unique name unlikely to be used by YNAB devs
-   
-	if ( typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined' && $('.is-debt-payment-category.is-master-category').length ) {
-
-		var debtPaymentCategories = $('.is-debt-payment-category.is-sub-category');
-		var accountName = {};
-		var accountBalance = {};
-		var accountMatch = {};
-		
-		
-		$(debtPaymentCategories).each(function () {
-		  accountName = $(this).find('.budget-table-cell-name div.button-truncate').prop('title')
-		 
-		  var categoryBalance = $(this).find('.budget-table-cell-available-div .user-data.currency').html();
-		  categoryBalance = Number( categoryBalance.replace(/[^\d.-]/g, '') );
-		
-		  $('.nav-account-row').each(function () {
-		
-		    if ( $(this).find('.nav-account-name').prop('title') == accountName ) {
-		      accountMatch = true;
-		      accountBalance = $(this).find('.user-data.currency').html();
-		      accountBalance = Number( accountBalance.replace(/[^\d.-]/g, '') );
-		    }
-		
-		  });
-		
-		  if ( accountMatch ) {
-
-		  	if ( accountBalance + categoryBalance !== 0 ) { // warn if funds do not balance to 0
-
-		      	var $thisCategoryBalance = $(this).find('.budget-table-cell-available-div .user-data.currency')
-		      	if ( $thisCategoryBalance.hasClass('positive') ) {
-		      		$thisCategoryBalance.removeClass('positive').addClass('cautious');
-		      	};
-
-		  	};
-		
-		      accountMatch = false; // reset
-		  };
-		});
-
-  	};
-
-	setTimeout(checkCreditBalances_enhancedYNAB, 300);
-
+(function poll() {
+   if ( typeof ynabToolKit !== "undefined") {
+   		
+      ynabToolKit.featureOptions.checkCreditBalances = true;
+   	ynabToolKit.checkCreditBalances = function ()  {
+         
+            var debtPaymentCategories = $('.is-debt-payment-category.is-sub-category');
+            var accountName = {};
+            var accountBalance = {};
+            var accountMatch = {};
+      
+            $(debtPaymentCategories).each(function() {
+               accountName = $(this).find('.budget-table-cell-name div.button-truncate').prop('title')
+      
+               var categoryBalance = $(this).find('.budget-table-cell-available-div .user-data.currency').html();
+               categoryBalance = Number(categoryBalance.replace(/[^\d.-]/g, ''));
+      
+               $('.nav-account-row').each(function() {
+      
+                  if ( $(this).find('.nav-account-name').prop('title') == accountName) {
+                  	accountMatch = true;
+                  	accountBalance = $(this).find('.user-data.currency').html();
+                  	accountBalance = Number(accountBalance.replace(/[^\d.-]/g, ''));
+                  }
+      
+               });
+      
+               if (accountMatch) {
+      
+               	if (accountBalance + categoryBalance !== 0) { // warn if funds do not balance to 0
+      
+               		var $thisCategoryBalance = $(this).find('.budget-table-cell-available-div .user-data.currency');
+      
+               		if ($thisCategoryBalance.hasClass('positive')) {
+               			$thisCategoryBalance.removeClass('positive').addClass('cautious');
+               		}
+      
+               	}
+               	
+               	accountMatch = false; // reset
+               } // account match
+               
+            });
+         
+      };
+      
+   } else {
+   	setTimeout(poll, 250);
+   }		
 })();
+
+
+
+
+
+
+
 

--- a/src/common/res/features/highlight-negatives-negative/main.js
+++ b/src/common/res/features/highlight-negatives-negative/main.js
@@ -1,26 +1,31 @@
-(function highlightNegativesNegative_enhancedYNAB() { // give function unique name unlikely to be used by YNAB devs
-   
-	if ( typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined' && $('.budget-table-cell-available-div.user-data').length ) {
+	
+(function poll() {
+	if ( typeof ynabToolKit !== "undefined") {
+
+		ynabToolKit.featureOptions.highlightNegativesNegative = true;
+		ynabToolKit.highlightNegativesNegative = function ()  {
+	   		
+			var availableBalances = $('.budget-table-cell-available-div.user-data');
+			var categoryBalance = {};
+	
+			$(availableBalances).each(function () {
+				categoryBalance = $(this).find('.user-data.currency').html(); // get the value
+			  	categoryBalance = Number( categoryBalance.replace(/[^\d.-]/g, '') ); // force data type as number
+			  	
+			
+				if ( categoryBalance < 0 ) {
+					
+				    if ( $(this).find('.user-data.currency').hasClass('cautious') ) {
+				    	$(this).find('.user-data.currency').removeClass('cautious').addClass('negative') 
+				    };
+				};
+	
+			});
+	
+		};
 		
-		var availableBalances = $('.budget-table-cell-available-div.user-data');
-		var categoryBalance = {};
-
-		$(availableBalances).each(function () {
-			categoryBalance = $(this).find('.user-data.currency').html(); // get the value
-		  	categoryBalance = Number( categoryBalance.replace(/[^\d.-]/g, '') ); // force data type as number
-		  	
-		
-			if ( categoryBalance < 0 ) {
-				
-			    if ( $(this).find('.user-data.currency').hasClass('cautious') ) {
-			    	$(this).find('.user-data.currency').removeClass('cautious').addClass('negative') 
-			    };
-			};
-
-		});
-
-	}
-	setTimeout(highlightNegativesNegative_enhancedYNAB, 300);
-
+	} else {
+		setTimeout(poll, 250);
+	}		
 })();
 

--- a/src/common/res/features/init/actOnChange.js
+++ b/src/common/res/features/init/actOnChange.js
@@ -1,16 +1,18 @@
 window.ynabToolKit = new function() {
 	
+	// Set 'ynabToolKit.debugNodes = true' to print changes the mutationObserver sees
+	// during page interactions and updates to the developer tools console.
 	this.debugNodes = false,
 	
+	// This variable is populated by each active script loaded inside the ynabToolKit object
 	this.featureOptions = {},
 		
-	// setting up a single mutationObserver that can be called by each feature
+	// Setting up a single mutationObserver that can be called by each feature
 	this.actOnChange = function() {
 
 		MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
 
 		var observer = new MutationObserver(function(mutations, observer) {
-			// Loop through all the mutations and nodes to see if navigation area was added
 			
 			if (ynabToolKit.debugNodes) {
 				console.log('NEW NODES');
@@ -27,7 +29,7 @@ window.ynabToolKit = new function() {
 					var $node = $(this);
 
 					
-						// Changes are detected in the credit balance master category
+						// Changes are detected in the category balances
 						if ($node.hasClass("budget-table-cell-available-div")) {
 							
 							if ( ynabToolKit.featureOptions.checkCreditBalances ){
@@ -39,7 +41,7 @@ window.ynabToolKit = new function() {
 							
 						} else
 						
-						// Maybe we find the screen containing the account balances again
+						// The user has returned back to the budget screen
 						if ($node.hasClass('budget-table-row')) {
 							
 							if ( ynabToolKit.featureOptions.checkCreditBalances ){
@@ -54,7 +56,7 @@ window.ynabToolKit = new function() {
 						if ($node.hasClass( "options-shown")) {
 							
 							if ( ynabToolKit.featureOptions.removeZeroCategories ) {				
-								ynabToolKit.removeZeroCategories(); // do something
+								ynabToolKit.removeZeroCategories();
 							}
 						}				
 
@@ -65,9 +67,10 @@ window.ynabToolKit = new function() {
 			if (ynabToolKit.debugNodes) {
 				console.log('###')
 			}
-			
+		
 		});
 
+		// This finally says 'Watch for changes' and only needs to be called the one time
 		observer.observe($('.ember-view.layout')[0], {
 			subtree : true,
 			childList : true,
@@ -77,22 +80,24 @@ window.ynabToolKit = new function() {
 	};
 
 	
-}; // end new ynabToolKit function
+}; // end ynabToolKit object
 
+// This poll() function will only need to run until we find that the DOM is ready
+// For certain functions, we may run them once automatically on page load before 'changes' occur
 (function poll() {
     if (typeof Em !== 'undefined' && typeof Ember !== 'undefined' 
           && typeof $ !== 'undefined' && $('.ember-view.layout').length) {
     	
-    	// Run each activated feature once once the DOM is ready
+
     	if ( ynabToolKit.featureOptions.checkCreditBalances ) {
-    	  ynabToolKit.checkCreditBalances(); // check initial state of credit balances
+    	  ynabToolKit.checkCreditBalances();
     	}
     	
     	if ( ynabToolKit.featureOptions.highlightNegativesNegative ){
-    		ynabToolKit.highlightNegativesNegative(); // set consistent colour for all negative balances
+    		ynabToolKit.highlightNegativesNegative(); 
     	}
     	
-    	// initialize the mutation observer so we don't need to use setTimeout()
+    	// Activate the mutationObserver so we don't need to use setTimeout() anymore
         ynabToolKit.actOnChange(); 
     } else {
        setTimeout(poll, 250);

--- a/src/common/res/features/init/actOnChange.js
+++ b/src/common/res/features/init/actOnChange.js
@@ -1,0 +1,101 @@
+window.ynabToolKit = new function() {
+	
+	this.debugNodes = false,
+	
+	this.featureOptions = {},
+		
+	// setting up a single mutationObserver that can be called by each feature
+	this.actOnChange = function() {
+
+		MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+
+		var observer = new MutationObserver(function(mutations, observer) {
+			// Loop through all the mutations and nodes to see if navigation area was added
+			
+			if (ynabToolKit.debugNodes) {
+				console.log('NEW NODES');
+			}
+			
+			mutations.forEach(function(mutation) {
+				var newNodes = mutation.target;
+				if (ynabToolKit.debugNodes) {
+					console.log(newNodes);
+				}
+
+				var $nodes = $(newNodes); // jQuery set
+				$nodes.each(function() {
+					var $node = $(this);
+
+					
+						// Changes are detected in the credit balance master category
+						if ($node.hasClass("budget-table-cell-available-div")) {
+							
+							if ( ynabToolKit.featureOptions.checkCreditBalances ){
+								ynabToolKit.checkCreditBalances();
+							}
+							if ( ynabToolKit.featureOptions.highlightNegativesNegative ){
+								ynabToolKit.highlightNegativesNegative();
+							}
+							
+						} else
+						
+						// Maybe we find the screen containing the account balances again
+						if ($node.hasClass('budget-table-row')) {
+							
+							if ( ynabToolKit.featureOptions.checkCreditBalances ){
+								ynabToolKit.checkCreditBalances();
+							}
+							if ( ynabToolKit.featureOptions.highlightNegativesNegative ){
+								ynabToolKit.highlightNegativesNegative();
+							}
+						}
+						
+						// We found a modal pop-up
+						if ($node.hasClass( "options-shown")) {
+							
+							if ( ynabToolKit.featureOptions.removeZeroCategories ) {				
+								ynabToolKit.removeZeroCategories(); // do something
+							}
+						}				
+
+				}); // each node mutation event
+
+			}); // each mutation event
+			
+			if (ynabToolKit.debugNodes) {
+				console.log('###')
+			}
+			
+		});
+
+		observer.observe($('.ember-view.layout')[0], {
+			subtree : true,
+			childList : true,
+			characterData : true,
+			attributeFilter : [ 'class' ]
+		});
+	};
+
+	
+}; // end new ynabToolKit function
+
+(function poll() {
+    if (typeof Em !== 'undefined' && typeof Ember !== 'undefined' 
+          && typeof $ !== 'undefined' && $('.ember-view.layout').length) {
+    	
+    	// Run each activated feature once once the DOM is ready
+    	if ( ynabToolKit.featureOptions.checkCreditBalances ) {
+    	  ynabToolKit.checkCreditBalances(); // check initial state of credit balances
+    	}
+    	
+    	if ( ynabToolKit.featureOptions.highlightNegativesNegative ){
+    		ynabToolKit.highlightNegativesNegative(); // set consistent colour for all negative balances
+    	}
+    	
+    	// initialize the mutation observer so we don't need to use setTimeout()
+        ynabToolKit.actOnChange(); 
+    } else {
+       setTimeout(poll, 250);
+    }
+ })();
+

--- a/src/common/res/features/remove-zero-categories/main.js
+++ b/src/common/res/features/remove-zero-categories/main.js
@@ -1,15 +1,27 @@
-(function removeZeroCategoriesFromCoverOverbudgeting() {
+	
+(function poll() {
+	
+	if ( typeof ynabToolKit !== "undefined") {
 
-  if (typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined') {
-    var coverOverbudgetingCategories = $( ".modal-budget-overspending .options-shown .ynab-select-options" ).children('li');
-    coverOverbudgetingCategories.each(function(i) {
-      var t = $(this).text(); // Category balance text.
-      var categoryBalance = parseInt(t.substr(t.indexOf(":"), t.length).replace(/[^\d-]/g, ''));
-      if (categoryBalance <= 0) {
-        $(this).remove();
-      }
-    });
-  }
-
-  setTimeout(removeZeroCategoriesFromCoverOverbudgeting, 50);
+		ynabToolKit.featureOptions.removeZeroCategories = true;
+		ynabToolKit.removeZeroCategories = function ()  {
+		    var coverOverbudgetingCategories = $( ".modal-budget-overspending .options-shown .ynab-select-options" ).children('li');
+		    coverOverbudgetingCategories.each(function(i) {
+		      var t = $(this).text(); // Category balance text.
+		      var categoryBalance = parseInt(t.substr(t.indexOf(":"), t.length).replace(/[^\d-]/g, ''));
+		      if (categoryBalance <= 0) {
+		        $(this).remove();
+		      }
+		    });
+		};
+		
+	} else {
+		setTimeout(poll, 250);
+	}		
 })();
+	
+	
+	
+
+	
+	    


### PR DESCRIPTION
Re: https://trello.com/c/mEPvAQUE/3-find-a-better-way-to-observe-dom-changes-and-inject-content-either-by-hooking-ember-internals-or-by-building-a-concise-non-polli

We now can use a mutationObserver in place of constant DOM polling. I also have introduced a global variable called ynabToolKit that each script that populate with their own functions.

Features updated and tested:
- Check credit balances
- Highlight negatives negative
- Remove zero/negative categories

The benefit of using mutationObserver is that we only need to run scripts when the user makes a relevant change to their account that affects an area of concern. The benefit of a global script is that all of our code and functions is isolated from the production code. It also means a nicer visual experience for the users with hopefully imperceptible delays between production code and our own.

I tackled the two feature I previously built due to familiarity and I also addressed the DOM polling for the "remove zero categories" feature as well. I am playing around with migrating the move money auto complete feature next.

Due to a major problem with Windows line endings that made useless changes to the Kango files, this branch contains all of my collected changes over the weekend, so it's light on commits. You can checkout https://github.com/Niictar/ynab-enhanced/tree/single-mutation-observer if you are looking to see more granular steps up this point.

If this pattern works for us, I can begin to introduce this to each of the other features that rely on DOM polling. This has been tested with both Chrome and Firefox.

Let me know what you think.