### PR TITLE
Added "remove positive highlight" feature

### DIFF
--- a/src/common/main.js
+++ b/src/common/main.js
@@ -164,3 +164,7 @@ if (kango.storage.getItem('daysOfBuffering')) {
   injectCSS('res/features/days-of-buffering/main.css');
   injectScript('res/features/days-of-buffering/main.js');
 }
+
+if (kango.storage.getItem('removePositiveHighlight')) {
+  injectCSS('res/features/remove-positive-highlight/main.css');
+}

--- a/src/common/options.html
+++ b/src/common/options.html
@@ -229,6 +229,18 @@
                               </div>
                             </div>
                           </div>
+						  
+						  <div class="container col-xs-11">
+                            <div class="row col-xs-10">
+                              <div class="col-xs-2">
+                                <input type="checkbox" id="removePositiveHighlight" name="removePositiveHighlight" aria-describedby="removePositiveHighlightHelpBlock">
+                              </div>
+                              <div class="col-xs-8">
+                                <label for="removePositiveHighlight">Unhighlight all Positive Category Balances</label>
+                                <span id="removePositiveHighlightHelpBlock" class="help-block">Removes distracting highlight color from positive (or zero) category balances, and colors positive balances green instead.</span>
+                              </div>
+                            </div>
+                          </div>
 
                           <div class="container col-xs-11">
                             <div class="row col-xs-10">

--- a/src/common/options.html
+++ b/src/common/options.html
@@ -230,7 +230,7 @@
                             </div>
                           </div>
 						  
-						  <div class="container col-xs-11">
+                          <div class="container col-xs-11">
                             <div class="row col-xs-10">
                               <div class="col-xs-2">
                                 <input type="checkbox" id="removePositiveHighlight" name="removePositiveHighlight" aria-describedby="removePositiveHighlightHelpBlock">

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -48,6 +48,7 @@ function saveOptions() {
   saveCheckboxOption('hideAOM');
   saveCheckboxOption('checkCreditBalances');
   saveCheckboxOption('highlightNegativesNegative');
+  saveCheckboxOption('removePositiveHighlight');
   saveCheckboxOption('enableRetroCalculator');
   saveCheckboxOption('removeZeroCategories');
   saveCheckboxOption('moveMoneyDialog');
@@ -82,6 +83,7 @@ function restoreOptions() {
   restoreCheckboxOption('hideAOM');
   restoreCheckboxOption('checkCreditBalances');
   restoreCheckboxOption('highlightNegativesNegative');
+  restoreCheckboxOption('removePositiveHighlight');
   restoreCheckboxOption('enableRetroCalculator');
   restoreCheckboxOption('removeZeroCategories');
   restoreCheckboxOption('moveMoneyDialog');

--- a/src/common/res/features/remove-positive-highlight/main.css
+++ b/src/common/res/features/remove-positive-highlight/main.css
@@ -1,0 +1,20 @@
+.budget-table-row.is-sub-category > .budget-table-cell-available .positive {
+	background-color: transparent;
+	color: #16a336;
+	font-weight: bold;
+}
+
+.budget-table-row.is-sub-category > .budget-table-cell-available .positive:hover {
+	background-color: transparent;
+	color: #138b2e;
+}
+
+.budget-table-row.is-sub-category > .budget-table-cell-available .zero {
+	background-color: transparent;
+	color: #cfd5d8;
+}
+
+.budget-table-row.is-sub-category.is-checked > .budget-table-cell-available .positive,
+.budget-table-row.is-sub-category.is-checked > .budget-table-cell-available .zero {
+	color: #fff;
+}


### PR DESCRIPTION
I find the green highlight on categories with positive balances to be extremely distracting. Only categories that need attention should have a distinctive highlight.

This CSS-only option removes the distracting background from positive balance cells and instead colors the text itself (and makes it bold). The same applies to zero-balance cells, except without the bold.