### PR TITLE
Firefox doesn't want to read text using innerText. Using textContent.

### DIFF
--- a/src/common/res/features/move-money-autocomplete/main.js
+++ b/src/common/res/features/move-money-autocomplete/main.js
@@ -120,7 +120,7 @@
 				for (i = 0; i < select.children.length; i++) {
 					var entry = select.children[i];
 					var match = true;
-					var entryTxt = entry.innerText;
+					var entryTxt = entry.textContent;
 					for (p = 0; p < parts.length; p++) {
 						var part = parts[p].toUpperCase();
 						if (entryTxt.toUpperCase().lastIndexOf(part) < 0) {


### PR DESCRIPTION
Simple fix for Firefox that allows auto-complete to work again.