### PR TITLE
Update inspector colours

### DIFF
--- a/src/common/main.js
+++ b/src/common/main.js
@@ -74,6 +74,11 @@ if (kango.storage.getItem('checkCreditBalances')) {
   injectScript('res/features/check-credit-balances/main.js');
 }
 
+if (kango.storage.getItem('checkCreditBalances') || kango.storage.getItem('highlightNegativesNegative')) {
+  // features that update presentation classes should have this enabled by default for consistency
+  injectScript('res/features/inspector-colours/main.js'); 
+}
+
 if (kango.storage.getItem('enableRetroCalculator')) {
   injectScript('res/features/ynab-4-calculator/main.js');
 }

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -64,6 +64,14 @@
                 }
                 
               }
+
+              if ($node.hasClass('is-sub-category') && $node.hasClass('is-checked')) {
+
+                if ( ynabToolKit.featureOptions.inspectorColours ) {  
+                  ynabToolKit.inspectorColours();
+                }
+
+              }
   
           }); // each node mutation event
   

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -67,8 +67,8 @@
 
               if ($node.hasClass('is-sub-category') && $node.hasClass('is-checked')) {
 
-                if ( ynabToolKit.featureOptions.inspectorColours ) {  
-                  ynabToolKit.inspectorColours();
+                if ( ynabToolKit.featureOptions.updateInspectorColours ) {  
+                  ynabToolKit.updateInspectorColours();
                 }
 
               }

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -38,6 +38,9 @@
                 if ( ynabToolKit.featureOptions.highlightNegativesNegative ){
                   ynabToolKit.highlightNegativesNegative();
                 }
+                if ( ynabToolKit.featureOptions.updateInspectorColours ) {  
+                    ynabToolKit.updateInspectorColours();
+                  }
                 
               } else
               

--- a/src/common/res/features/colour-blind-mode/main.css
+++ b/src/common/res/features/colour-blind-mode/main.css
@@ -1,3 +1,7 @@
+/* ======== General colours / shapes ======== */
+.inspector dt {
+	color: black !important;
+}
 
 /* ======== Cautious colours / shapes ======== */
 .budget-table-row.is-sub-category > .budget-table-cell-available .cautious {
@@ -5,7 +9,7 @@
 }
 
 .inspector-overview-available .currency.cautious {
-    background-color: #19a3c5;
+    background-color: #19a3c5 !important;;
 }
 
 .budget-table-row.is-sub-category > .budget-table-cell-available .cautious:hover {
@@ -38,8 +42,12 @@ ul.is-sub-category > li.budget-table-cell-available > div.budget-table-cell-avai
 /* ======== Positive colours / shapes ======== */
 ul.is-sub-category > li.budget-table-cell-available > div.budget-table-cell-available-div > span.positive {
     background-color: #009e73 !important;
+    color: #fff !important;
+    font-weight: normal !important;
 }
 
 .inspector-overview-available .currency.positive {
-    background-color: #009e73 !important;
+    background-color: #009e73 !important;;
+    color: #fff !important;
+    font-weight: normal !important;
 }

--- a/src/common/res/features/inspector-colours/main.js
+++ b/src/common/res/features/inspector-colours/main.js
@@ -1,0 +1,24 @@
+(function poll() {
+  if ( typeof ynabToolKit !== "undefined" && ynabToolKit.actOnChangeInit === true ) {
+
+    ynabToolKit.featureOptions.inspectorColours = true;
+    ynabToolKit.inspectorColours = function ()  {
+
+      if ( !$('.budget-inspector-multiple').length ) {
+
+        var selectedSubCat = $('.budget-table-row.is-sub-category.is-checked').find('.budget-table-cell-available-div span.currency')[0]
+        var inspectorAvailableText = $('.inspector-overview-available').find('dt');
+        var inspectorAvailableFunds = $('.inspector-overview-available').find('span');
+        if (!$(selectedSubCat).hasClass('positive')) {
+          $(inspectorAvailableText).attr("class", $(selectedSubCat).attr("class"));
+        }
+        $(inspectorAvailableFunds).attr("class", $(selectedSubCat).attr("class"));
+
+      }
+
+    };
+    
+  } else {
+    setTimeout(poll, 250);
+  }   
+})();

--- a/src/common/res/features/inspector-colours/main.js
+++ b/src/common/res/features/inspector-colours/main.js
@@ -10,7 +10,7 @@
         var inspectorAvailableText = $('.inspector-overview-available').find('dt');
         var inspectorAvailableFunds = $('.inspector-overview-available').find('span');
         if (!$(selectedSubCat).hasClass('positive')) {
-          $(inspectorAvailableText).attr("class", $(selectedSubCat).attr("class"));
+          $(inspectorAvailableText).attr("class", $(selectedSubCat).attr("class")).removeClass('currency');
         }
         $(inspectorAvailableFunds).attr("class", $(selectedSubCat).attr("class"));
 

--- a/src/common/res/features/inspector-colours/main.js
+++ b/src/common/res/features/inspector-colours/main.js
@@ -1,8 +1,8 @@
 (function poll() {
   if ( typeof ynabToolKit !== "undefined" && ynabToolKit.actOnChangeInit === true ) {
 
-    ynabToolKit.featureOptions.inspectorColours = true;
-    ynabToolKit.inspectorColours = function ()  {
+    ynabToolKit.featureOptions.updateInspectorColours = true;
+    ynabToolKit.updateInspectorColours = function ()  {
 
       if ( !$('.budget-inspector-multiple').length ) {
 

--- a/src/common/res/features/remove-positive-highlight/main.css
+++ b/src/common/res/features/remove-positive-highlight/main.css
@@ -4,7 +4,8 @@
 	font-weight: bold;
 }
 
-.budget-table-row.is-sub-category > .budget-table-cell-available .positive:hover {
+.budget-table-row.is-sub-category > .budget-table-cell-available .positive:hover,
+.inspector-overview-available .positive {
 	background-color: transparent;
 	color: #138b2e;
 }


### PR DESCRIPTION
Added a new feature that automatically enables itself if there is a feature that updates the presentation classes on the available balance highlights. 

It keeps the colours in the inspector matching the available balance in the subcategory. 

Also, reinforced rules for colourblind mode so that a user doesn't have an accidental conflict with 'remove positive highlights' feature if they are both on at the same time (colourblind mode wins).