### PR TITLE
Pacing feature activates based on mutationObserver instead of DOM polling

### DIFF
--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -40,7 +40,7 @@
                 }
                 if ( ynabToolKit.featureOptions.updateInspectorColours ) {  
                     ynabToolKit.updateInspectorColours();
-                  }
+                }
                 
               } else
               
@@ -67,7 +67,8 @@
                 }
                 
               }
-
+              
+              // User has selected a specific sub-category
               if ($node.hasClass('is-sub-category') && $node.hasClass('is-checked')) {
 
                 if ( ynabToolKit.featureOptions.updateInspectorColours ) {  
@@ -75,6 +76,16 @@
                 }
 
               }
+              
+              // Values in the header total have changed
+              if ($node.hasClass('budget-header-totals-cell-value')) {
+            	  
+            	  if ( ynabToolKit.featureOptions.insertPacingColumns ){
+            		  ynabToolKit.insertPacingColumns();
+            	  }
+            	  
+              }
+              
   
           }); // each node mutation event
   

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -15,7 +15,7 @@
       var observer = new MutationObserver(function(mutations, observer) {
         
         if (ynabToolKit.debugNodes) {
-          console.log('NEW NODES');
+          console.log('MODIFIED NODES');
         }
         
         mutations.forEach(function(mutation) {
@@ -32,12 +32,6 @@
               // Changes are detected in the category balances
               if ($node.hasClass("budget-table-cell-available-div")) {
                 
-                if ( ynabToolKit.featureOptions.checkCreditBalances ){
-                  ynabToolKit.checkCreditBalances();
-                }
-                if ( ynabToolKit.featureOptions.highlightNegativesNegative ){
-                  ynabToolKit.highlightNegativesNegative();
-                }
                 if ( ynabToolKit.featureOptions.updateInspectorColours ) {  
                     ynabToolKit.updateInspectorColours();
                 }
@@ -45,7 +39,7 @@
               } else
               
               // The user has returned back to the budget screen
-              if ($node.hasClass('budget-table-row')) {
+              if ($node.hasClass('budget-inspector')) {
                 
                 if ( ynabToolKit.featureOptions.checkCreditBalances ){
                   ynabToolKit.checkCreditBalances();
@@ -53,6 +47,10 @@
                 if ( ynabToolKit.featureOptions.highlightNegativesNegative ){
                   ynabToolKit.highlightNegativesNegative();
                 }
+                if ( ynabToolKit.featureOptions.insertPacingColumns ){
+          		  ynabToolKit.insertPacingColumns();
+          	  	}
+                
               }
               
               // We found a modal pop-up
@@ -77,14 +75,7 @@
 
               }
               
-              // Values in the header total have changed
-              if ($node.hasClass('budget-header-totals-cell-value')) {
-            	  
-            	  if ( ynabToolKit.featureOptions.insertPacingColumns ){
-            		  ynabToolKit.insertPacingColumns();
-            	  }
-            	  
-              }
+              
               
   
           }); // each node mutation event

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -48,7 +48,7 @@
                   ynabToolKit.highlightNegativesNegative();
                 }
                 if ( ynabToolKit.featureOptions.insertPacingColumns ){
-          		  ynabToolKit.insertPacingColumns();
+                  ynabToolKit.insertPacingColumns();
           	  	}
                 
               }

--- a/src/common/res/features/pacing/main.js
+++ b/src/common/res/features/pacing/main.js
@@ -1,108 +1,116 @@
-function ynabEnhancedFormatCurrency(e, html) {
-  var n, r, a;
-  e = ynab.formatCurrency(e);
-  n = ynab.YNABSharedLib.currencyFormatter.getCurrency();
-  a = Ember.Handlebars.Utils.escapeExpression(n.currency_symbol);
-  if (html) {
-      a = '<bdi>' + a + '</bdi>';
-  }
-  n.symbol_first ? (r = '-' === e.charAt(0), e = r ? '-' + a + e.slice(1) : a + e) : e += a;
-  return new Ember.Handlebars.SafeString(e);
-}
+(function poll() {
+  if ( typeof ynabToolKit !== "undefined" && ynabToolKit.actOnChangeInit === true ) {
 
-// Calculate the proportion of the month that has been spent -- only works for the current month
-function timeSpent() {
-  var today = new Date();
-  var daysInMonth = new Date(today.getYear(), today.getMonth(), 0).getDate();
-  var day = Math.max(today.getDate()-1,1);
+    ynabToolKit.featureOptions.insertPacingColumns = true;
+    ynabToolKit.insertPacingColumns = function ()  {
 
-  return day/daysInMonth;
-}
+		function  formatCurrency(e, html) {
+		  var n, r, a;
+		  e = ynab.formatCurrency(e);
+		  n = ynab.YNABSharedLib.currencyFormatter.getCurrency();
+		  a = Ember.Handlebars.Utils.escapeExpression(n.currency_symbol);
+		  if (html) {
+		      a = '<bdi>' + a + '</bdi>';
+		  }
+		  n.symbol_first ? (r = '-' === e.charAt(0), e = r ? '-' + a + e.slice(1) : a + e) : e += a;
+		  return new Ember.Handlebars.SafeString(e);
+		}
+		
+		// Calculate the proportion of the month that has been spent -- only works for the current month
+		function timeSpent() {
+		  var today = new Date();
+		  var daysInMonth = new Date(today.getYear(), today.getMonth(), 0).getDate();
+		  var day = Math.max(today.getDate()-1,1);
+		
+		  return day/daysInMonth;
+		}
+		
+		// Determine whether the selected month is the current month
+		function inCurrentMonth() {
+		  var today = new Date();
+		  var selectedMonth = new Date($('.budget-header-calendar-date-button').text());
+		  return selectedMonth.getMonth() == today.getMonth() && selectedMonth.getYear() == today.getYear();
+		}
+		
 
-// Determine whether the selected month is the current month
-function inCurrentMonth() {
-  var today = new Date();
-  var selectedMonth = new Date($('.budget-header-calendar-date-button').text());
-  return selectedMonth.getMonth() == today.getMonth() && selectedMonth.getYear() == today.getYear();
-}
+		var tv = ynab.YNABSharedLib.getBudgetViewModel_AllBudgetMonthsViewModel()._result.getAllAccountTransactionsViewModel();
+		var month = tv.getBudgetMonthViewModelForCurrentMonth().getMonth();
+		var allTransactions = tv.getVisibleTransactionDisplayItemsForMonth(month);
+		
+		if(inCurrentMonth()) {
+		  // Make room for the column
+		  $('#ynab-toolkit-pacing-style').remove();
+		  $('<style type="text/css" id="ynab-toolkit-pacing-style"> .budget-table-cell-available { width: 10% !important; } </style>').appendTo('head');
+		} else {
+		  $('#ynab-toolkit-pacing-style').remove();
+		  $('<style type="text/css" id="ynab-toolkit-pacing-style"> .budget-table-cell-pacing { display: none; } </style>').appendTo('head');
+		}
+		
+		
+		$('.budget-table-cell-pacing').remove()
+		
+		$(".budget-table-header .budget-table-cell-available").after($('<li class="budget-table-cell-pacing"><strong>PACING</strong></li>'));
+		
+		$('.budget-table-row').each(function(){ 
+		  var available = ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat($(this).find('.budget-table-cell-available').text());
+		  var activity = -ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat($(this).find('.budget-table-cell-activity').text());
+		  var budgeted = available+activity;
+		  var burned = activity/budgeted;
+		  var pace = burned/timeSpent();
+		
+		  var masterName = $.trim($(this).prevAll('.is-master-category').first().find('.budget-table-cell-name').text());
+		  var subcatName = $.trim($(this).find('.budget-table-cell-name').text());
+		
+		  var transactionCount = allTransactions.filter((el) => el.transferAccountId == null 
+		    && el.outflow > 0 && el.subCategoryNameWrapped == (masterName+": "+subcatName)).length;
+		
+		  var displayType = 'dollars';
+		  if(displayType == 'percentage') {
+		    if(pace > 1) {
+		      var temperature = 'warm';
+		    } else {
+		      var temperature = 'cool';
+		    }
+		    if(!isFinite(pace)) {
+		      var display = 999;
+		    } else {
+		      var display = Math.max(0,Math.round(pace*100));
+		    }
+		    if(pace > 0) {
+		      $(this).append('<li class="budget-table-cell-pacing"><span class="budget-table-cell-pacing-display '+temperature+'">'+display+'%</span></li>');
+		    }
+		  } else if (displayType == 'dollars') {
+		    display = Math.round((budgeted*timeSpent()-activity)*1000);
+		    if(available != 0 && activity != 0 && masterName != 'Credit Card Payments') {
+		      if(pace > 1) {
+		        var temperature = 'warm';
+		      } else if(activity != 0) {
+		        var temperature = 'cool';
+		      } else {
+		        var temperature = 'neutral';
+		      }
+		    } else {
+		      var temperature = 'neutral'; 
+		    }
+		
+		    if(display >= 0) {
+		      var tooltip = 'In '+transactionCount+' transaction'+(transactionCount != 1 ? 's' : '')+' you have spent '+ formatCurrency(display, false)+
+							' less than your available budget for this category '+Math.round(timeSpent()*100)+'% of the way through the month.';
+		    } else if(display < 0) {
+		      var tooltip = 'In '+transactionCount+' transaction'+(transactionCount != 1 ? 's' : '')+' you have spent '+ formatCurrency(-display, false)+
+							' more than your available budget for this category '+Math.round(timeSpent()*100)+'% of the way through the month.';
+		    }
+		    $(this).append('<li class="budget-table-cell-pacing"><span title="'+tooltip+'" class="budget-table-cell-pacing-display '+temperature+'">'+ formatCurrency(display, true)+'</span></li>');
+		  }
+		});
+		
 
-(
- function addPacingColumnToBudget() {
-  if (typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined' && !$('body').hasClass('is-init-loading')
-    && typeof ynab !== 'undefined') {
-    var tv = ynab.YNABSharedLib.getBudgetViewModel_AllBudgetMonthsViewModel()._result.getAllAccountTransactionsViewModel();
-    var month = tv.getBudgetMonthViewModelForCurrentMonth().getMonth();
-    var allTransactions = tv.getVisibleTransactionDisplayItemsForMonth(month);
-
-    if(inCurrentMonth()) {
-      // Make room for the column
-      $('#ynab-toolkit-pacing-style').remove();
-      $('<style type="text/css" id="ynab-toolkit-pacing-style"> .budget-table-cell-available { width: 10% !important; } </style>').appendTo('head');
-    } else {
-      $('#ynab-toolkit-pacing-style').remove();
-      $('<style type="text/css" id="ynab-toolkit-pacing-style"> .budget-table-cell-pacing { display: none; } </style>').appendTo('head');
-    }
+	};
+	ynabToolKit.insertPacingColumns();
 
 
-    $('.budget-table-cell-pacing').remove()
     
-    $(".budget-table-header .budget-table-cell-available").after($('<li class="budget-table-cell-pacing"><strong>PACING</strong></li>'));
-    
-    $('.budget-table-row').each(function(){ 
-      var available = ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat($(this).find('.budget-table-cell-available').text());
-      var activity = -ynab.YNABSharedLib.defaultInstance.currencyFormatter.unformat($(this).find('.budget-table-cell-activity').text());
-      var budgeted = available+activity;
-      var burned = activity/budgeted;
-      var pace = burned/timeSpent();
-   
-      var masterName = $.trim($(this).prevAll('.is-master-category').first().find('.budget-table-cell-name').text());
-      var subcatName = $.trim($(this).find('.budget-table-cell-name').text());
-
-      var transactionCount = allTransactions.filter((el) => el.transferAccountId == null 
-        && el.outflow > 0 && el.subCategoryNameWrapped == (masterName+": "+subcatName)).length;
-
-      var displayType = 'dollars';
-      if(displayType == 'percentage') {
-        if(pace > 1) {
-          var temperature = 'warm';
-        } else {
-          var temperature = 'cool';
-        }
-        if(!isFinite(pace)) {
-          var display = 999;
-        } else {
-          var display = Math.max(0,Math.round(pace*100));
-        }
-        if(pace > 0) {
-          $(this).append('<li class="budget-table-cell-pacing"><span class="budget-table-cell-pacing-display '+temperature+'">'+display+'%</span></li>');
-        }
-      } else if (displayType == 'dollars') {
-        display = Math.round((budgeted*timeSpent()-activity)*1000);
-        if(available != 0 && activity != 0 && masterName != 'Credit Card Payments') {
-          if(pace > 1) {
-            var temperature = 'warm';
-          } else if(activity != 0) {
-            var temperature = 'cool';
-          } else {
-            var temperature = 'neutral';
-          }
-        } else {
-          var temperature = 'neutral'; 
-        }
-
-        if(display >= 0) {
-          var tooltip = 'In '+transactionCount+' transaction'+(transactionCount != 1 ? 's' : '')+' you have spent '+ynabEnhancedFormatCurrency(display, false)+
-						' less than your available budget for this category '+Math.round(timeSpent()*100)+'% of the way through the month.';
-        } else if(display < 0) {
-          var tooltip = 'In '+transactionCount+' transaction'+(transactionCount != 1 ? 's' : '')+' you have spent '+ynabEnhancedFormatCurrency(-display, false)+
-						' more than your available budget for this category '+Math.round(timeSpent()*100)+'% of the way through the month.';
-        }
-        $(this).append('<li class="budget-table-cell-pacing"><span title="'+tooltip+'" class="budget-table-cell-pacing-display '+temperature+'">'+ynabEnhancedFormatCurrency(display, true)+'</span></li>');
-      }
-    });
-
-  }
-
-  setTimeout(addPacingColumnToBudget, 500);
+  } else {
+    setTimeout(poll, 250);
+  }   
 })();
-


### PR DESCRIPTION
Enhancement re: issue #55 

Running this feature with setTimeout(function, 500) was causing massive slowdowns (probably from the mutationObserver acting on every change to every budgeting row twice every second.

The feature now only runs when there is an update to the DOM as observed by actOnChange so we don't need to rely on DOM polling to feed it updates. This change does seem to run the feature reliably.

No changes to logic or Firefox compatibility introduced with this update beyond moving the functions inside ynabToolKit and activating with actOnChange.