### PR TITLE
Exclude outflows from Tracking accs from DoB calculation

### DIFF
--- a/src/common/options.html
+++ b/src/common/options.html
@@ -323,7 +323,7 @@
                               </div>
                               <div class="col-xs-8">
                                 <label for="daysOfBuffering">Add Days of Buffering Metric</label>
-                                <span id="daysOfBufferingHelpBlock" class="help-block">This calculation shows how long your money would likely last if you never earned another cent based on your average spending. We know that no month is 'average' but this should give you some idea of how much of a buffer you have.</span>
+                                <span id="daysOfBufferingHelpBlock" class="help-block">This calculation shows how long your money would likely last if you never earned another cent based on your average spending. We know that no month is 'average' but this should give you some idea of how much of a buffer you have. Equal to budget accs total divided by the average daily outflow. That comes from sum of all outflow transactions from budget accs only divided by the age of budget in days.</span>
                               </div>
                             </div>
                           </div>

--- a/src/common/res/features/days-of-buffering/main.js
+++ b/src/common/res/features/days-of-buffering/main.js
@@ -46,7 +46,8 @@ function ynabEnhancedDoBCalculate() {
     // scheduledTransaction shouldn't count too because they are not paid.
     var outflow_transactions = transactions.filter((el) => el.displayItemType == "transaction" 
                                                     && el.transferAccountId == null 
-                                                    && el.outflow > 0);
+                                                    && el.outflow > 0
+                                                    && el.getAccount().onBudget);
     var totalOutflow = Array.from(outflow_transactions, (i) => i.outflow).reduce((a, b) => a + b, 0);
     var averageDailyOutflow = totalOutflow / totalDays;
     var budgetAccountsTotal = ynab.YNABSharedLib.getBudgetViewModel_SidebarViewModel()._result.getOnBudgetAccountsBalance();


### PR DESCRIPTION
I agree with some users that this should be done. I think people mustn't use Tracking accounts in day-to-day budgeting.

I've also added clarification because of big number of questions about how it really works.