### PR TITLE
Added clarity on how to contribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ All of these are configurable with options in the extension options page.
 Roadmap
 -------
 
-Features under consideration and the general status of the project is on [our Trello Board](https://trello.com/b/EzOvXlil/ynab-enhanced-roadmap). Feel free to vote and comment. To suggest new features, please visit the YNAB Forum thread here and comment. Forum user @stephywephy is managing the features there and will make sure it ends up in Trello.
+Features under consideration and the general status of the project and roadmap is on [our Trello Board](https://trello.com/b/EzOvXlil/ynab-enhanced-roadmap). Feel free to vote and comment. To suggest new features, please visit the YNAB Forum thread here and comment. Forum user @stephywephy is managing the features there and will make sure it ends up in Trello.
 
-If you want to contribute, it's best if you can let us know so we don't double up on effort. You can see what is being worked on and by whom on the roadmap. Contact @blarg on the forums to get started.
+Contributions are greatly welcomed. If you want to contribute, it's best if you can let us know so we don't double up on effort. You can see what is being worked on and by whom on the roadmap. If you can't find what you want to build on the roadmap, feel free to put a note up on the github issues board to let the team know you're working on something new. When your code is ready, submit a pull request. You can also contact @blarg on the forums.
 
 Building the Code
 -----------------


### PR DESCRIPTION
I noticed on a reddit discussion where someone felt discouraged to contribute because they didn't figure out how to announce they were working on something new on Trello. Since new cards can't be created by new contributors, I figured they could put a notice up on the issues board after reviewing everything else.