### PR TITLE
Stop-gap refactor of actOnChange

### DIFF
--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -18,6 +18,7 @@
           console.log('MODIFIED NODES');
         }
         
+        // Reset the digest of changed nodes on each unique mutation event
         ynabToolKit.digest = new Array();
         
         mutations.forEach(function(mutation) {
@@ -82,15 +83,14 @@
         	// We found a modal pop-up
         	if ($(ynabToolKit.digest[i]).hasClass( "options-shown")) {
         	  
-        	  if ( ynabToolKit.featureOptions.removeZeroCategories ) {        
-        	    ynabToolKit.removeZeroCategories();
-        	  }
-        	
-        	  if ( ynabToolKit.featureOptions.moveMoneyAutoComplete ) {       
-        	    ynabToolKit.moveMoneyAutoComplete();
-        	  }
+				if ( ynabToolKit.featureOptions.removeZeroCategories ) {        
+				  ynabToolKit.removeZeroCategories();
+				}
+				if ( ynabToolKit.featureOptions.moveMoneyAutoComplete ) {       
+				  ynabToolKit.moveMoneyAutoComplete();
+				}
 
-        	  break;
+				break;
         	  
         	}
         }
@@ -100,11 +100,11 @@
         	// User has selected a specific sub-category
         	if ( $(ynabToolKit.digest[i]).hasClass('is-sub-category') && $(ynabToolKit.digest[i]).hasClass('is-checked')) {
 
-        	  if ( ynabToolKit.featureOptions.updateInspectorColours ) {  
-        	    ynabToolKit.updateInspectorColours();
-        	  }
+				if ( ynabToolKit.featureOptions.updateInspectorColours ) {  
+				  ynabToolKit.updateInspectorColours();
+				}
 
-        	  break;
+				break;
 
         	}
         }

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -18,6 +18,8 @@
           console.log('MODIFIED NODES');
         }
         
+        ynabToolKit.digest = new Array();
+        
         mutations.forEach(function(mutation) {
           var newNodes = mutation.target;
           if (ynabToolKit.debugNodes) {
@@ -29,53 +31,7 @@
             var $node = $(this);
   
             
-              // Changes are detected in the category balances
-              if ($node.hasClass("budget-table-cell-available-div")) {
-                
-                if ( ynabToolKit.featureOptions.updateInspectorColours ) {  
-                    ynabToolKit.updateInspectorColours();
-                }
-                
-              } else
-              
-              // The user has returned back to the budget screen
-              if ($node.hasClass('budget-inspector')) {
-                
-                if ( ynabToolKit.featureOptions.checkCreditBalances ){
-                  ynabToolKit.checkCreditBalances();
-                }
-                if ( ynabToolKit.featureOptions.highlightNegativesNegative ){
-                  ynabToolKit.highlightNegativesNegative();
-                }
-                if ( ynabToolKit.featureOptions.insertPacingColumns ){
-                  ynabToolKit.insertPacingColumns();
-          	  	}
-                
-              }
-              
-              // We found a modal pop-up
-              if ($node.hasClass( "options-shown")) {
-                
-                if ( ynabToolKit.featureOptions.removeZeroCategories ) {        
-                  ynabToolKit.removeZeroCategories();
-                }
-  
-                if ( ynabToolKit.featureOptions.moveMoneyAutoComplete ) {       
-                  ynabToolKit.moveMoneyAutoComplete();
-                }
-                
-              }
-              
-              // User has selected a specific sub-category
-              if ($node.hasClass('is-sub-category') && $node.hasClass('is-checked')) {
-
-                if ( ynabToolKit.featureOptions.updateInspectorColours ) {  
-                  ynabToolKit.updateInspectorColours();
-                }
-
-              }
-              
-              
+            ynabToolKit.digest.push($node);             
               
   
           }); // each node mutation event
@@ -84,6 +40,73 @@
         
         if (ynabToolKit.debugNodes) {
           console.log('###')
+        }
+        
+        // Loop through the array and act if we find a relevant changed node in the digest
+        for ( var i = 0; i < ynabToolKit.digest.length; i++ ) { 
+
+        	// Changes are detected in the category balances
+        	if ($(ynabToolKit.digest[i]).hasClass("budget-table-cell-available-div")) {
+        	  
+        	  if ( ynabToolKit.featureOptions.updateInspectorColours ) {  
+        	      ynabToolKit.updateInspectorColours();
+        	  }
+
+        	  break;
+        	  
+        	} 
+        }
+
+        for ( var i = 0; i < ynabToolKit.digest.length; i++ ) { 
+
+        	// The user has returned back to the budget screen
+        	if ($(ynabToolKit.digest[i]).hasClass('budget-inspector')) {
+        	  
+        		if ( ynabToolKit.featureOptions.checkCreditBalances ){
+        		  ynabToolKit.checkCreditBalances();
+        		}
+        		if ( ynabToolKit.featureOptions.highlightNegativesNegative ){
+        		  ynabToolKit.highlightNegativesNegative();
+        		}
+        		if ( ynabToolKit.featureOptions.insertPacingColumns ){
+        		  ynabToolKit.insertPacingColumns();
+        		}
+
+        		break;
+        	}
+        	  
+        }
+
+        for ( var i = 0; i < ynabToolKit.digest.length; i++ ) { 
+
+        	// We found a modal pop-up
+        	if ($(ynabToolKit.digest[i]).hasClass( "options-shown")) {
+        	  
+        	  if ( ynabToolKit.featureOptions.removeZeroCategories ) {        
+        	    ynabToolKit.removeZeroCategories();
+        	  }
+        	
+        	  if ( ynabToolKit.featureOptions.moveMoneyAutoComplete ) {       
+        	    ynabToolKit.moveMoneyAutoComplete();
+        	  }
+
+        	  break;
+        	  
+        	}
+        }
+
+        for ( var i = 0; i < ynabToolKit.digest.length; i++ ) { 
+
+        	// User has selected a specific sub-category
+        	if ( $(ynabToolKit.digest[i]).hasClass('is-sub-category') && $(ynabToolKit.digest[i]).hasClass('is-checked')) {
+
+        	  if ( ynabToolKit.featureOptions.updateInspectorColours ) {  
+        	    ynabToolKit.updateInspectorColours();
+        	  }
+
+        	  break;
+
+        	}
         }
       
       });


### PR DESCRIPTION
When a change happens in YNAB, the mutation observer might find multiple changes to nodes that have the same class name. We only need to act on the first instance of a relevant mutated node during each mutation event and we should ignore the duplicates. 

Previously, we would fire our feature scripts for each node in each mutation event, regardless of duplicates. That was needless and bad for performance.

This can and will be improved further, but now gather all changed nodes into one array and then we only fire our feature scripts once for each mutation event, vastly improving performance for features like Pacing.