### PR TITLE
New Feature: Notifications for pending imports

### DIFF
--- a/src/common/main.js
+++ b/src/common/main.js
@@ -172,3 +172,8 @@ if (kango.storage.getItem('daysOfBuffering')) {
 if (kango.storage.getItem('removePositiveHighlight')) {
   injectCSS('res/features/remove-positive-highlight/main.css');
 }
+
+if (kango.storage.getItem('importNotification')) {
+  injectCSS('res/features/import-notification/import-notification.css');
+  injectScript('res/features/import-notification/import-notification.js');
+}

--- a/src/common/options.html
+++ b/src/common/options.html
@@ -121,6 +121,18 @@
                             </div>
                           </div>
 
+                          <div class="container col-xs-11">
+                            <div class="row col-xs-10">
+                              <div class="col-xs-2">
+                                <input type="checkbox" id="importNotification" name="importNotification" aria-describedby="importNotificationHelpBlock">
+                              </div>
+                              <div class="col-xs-8">
+                                <label for="importNotification">Show Import Notifications in Sidebar</label>
+                                <span id="importNotificationHelpBlock" class="help-block">Display a notification in the sidebar when there are transactions to be imported.</span>
+                              </div>
+                            </div>
+                          </div>
+
                           <!-- END GENERAL SETTINGS -->
                         </div>
 

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -74,6 +74,7 @@ function saveOptions() {
   saveCheckboxOption('accountsSelectedTotal');
   saveCheckboxOption('changeEnterBehavior');
   saveCheckboxOption('transferJump');
+  saveCheckboxOption('importNotification');
 
   saveSelectOption('budgetRowsHeight');
   saveSelectOption('reconciledTextColor');
@@ -109,6 +110,7 @@ function restoreOptions() {
   restoreCheckboxOption('accountsSelectedTotal');
   restoreCheckboxOption('changeEnterBehavior');
   restoreCheckboxOption('transferJump');
+  restoreCheckboxOption('importNotification');
 
   restoreSelectOption('budgetRowsHeight');
   restoreSelectOption('reconciledTextColor');

--- a/src/common/res/features/import-notification/import-notification.css
+++ b/src/common/res/features/import-notification/import-notification.css
@@ -1,0 +1,18 @@
+.notification {
+  border-radius: .3em !important; /* Without this the colors do not work */
+}
+
+.import-notification {
+  background-color: blue;
+}
+
+.nav-account-name {
+  padding-left: .7em;
+}
+
+.nav-account-notification {
+  white-space: nowrap;
+  padding-left: .2em;
+  -webkit-flex: 0 0 35px;
+  flex: 0 0 35px;
+}

--- a/src/common/res/features/import-notification/import-notification.js
+++ b/src/common/res/features/import-notification/import-notification.js
@@ -1,0 +1,32 @@
+(function poll() {
+   if ( typeof ynabToolKit !== 'undefined' && ynabToolKit.actOnChangeInit === true && typeof ynab.utilities.TransactionImportUtilities !== 'undefined' ) {
+       
+      ynabToolKit.featureOptions.importNotification = true;
+      ynabToolKit.importNotification = function ()  {
+        $('.import-notification').remove();
+        $('.nav-account-row').each(function(index, row) {
+          var account = Ember.View.views[$(row).attr('id')].get('data');
+          var transactions = ynab.utilities.TransactionImportUtilities.getImportTransactionsForAccount(account);
+          if(transactions.length >= 1) {
+            $(row).find('.nav-account-notification').append('<a class="notification import-notification">'+transactions.length+'</a>');
+          }
+        });  
+      };
+
+      // Hook transaction imports so that we can run our stuff when things change
+      ynab.YNABSharedLib.defaultInstance.entityManager._transactionEntityPropertyChanged.addHandler(ynabToolKit.importNotification);
+
+      ynabToolKit.importNotification(); // Run itself once
+   } else {
+     setTimeout(poll, 250);
+   }    
+})();
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This feature shows a numerical indicator in the left sidebar when there are transactions to be imported. It updates immediately when the import is finished, and works with the existing notifications (though they are not combined like "no category" and "pending approval").

![Demo](http://g.recordit.co/At6DTytKSI.gif)

**Tested in Firefox and Chrome**

*Note that I used the entity manager notifications instead of mutations. For imports, the transactions are actually already there -- with a specific "source" property set to "raw_import". Once the import button is clicked, they are actually input. In order to test this feature, I was forced to toggle this property several times.*