### PR TITLE
Increased the usability of the save/cancel buttons on the options screen

### DIFF
--- a/src/common/options.css
+++ b/src/common/options.css
@@ -27,6 +27,16 @@ label {
   margin: 18px 10px 0 0;
 }
 
+.page-header {
+  margin: 10px 0;
+}
+
+.page-header-buttons {
+  position: relative;
+  top: -6em;
+  margin-bottom: -6em;
+}
+
 .active-menu {
   -webkit-transition: all 0.3s ease;
   -moz-transition: all 0.3s ease;
@@ -35,10 +45,10 @@ label {
 }
 
 #settingsSaved {
-  position: fixed;
-  text-align: center;
-  z-index: 99;
-  top: 0px;
-  left: 0px;
-  width: 100%;
+    position: fixed;
+    text-align: center;
+    z-index: 99;
+    top: 0px;
+    left: 0px;
+    width: 100%;
 }

--- a/src/common/options.css
+++ b/src/common/options.css
@@ -35,6 +35,10 @@ label {
 }
 
 #settingsSaved {
-  margin: 15px 0 15px 0;
+  position: fixed;
   text-align: center;
+  z-index: 99;
+  top: 0px;
+  left: 0px;
+  width: 100%;
 }

--- a/src/common/options.html
+++ b/src/common/options.html
@@ -57,6 +57,11 @@
                               <i class="fa fa-cogs"></i> General Settings
                           </h2>
 
+                          <div class="col-xs-3 col-xs-offset-8 page-header-buttons">
+                            <button class="btn btn-lg btn-primary pull-right save-button">Save</button>
+                            <button class="btn btn-lg pull-right cancel-button">Cancel</button>
+                          </div>
+
                           <div class="container col-xs-11">
   	                        <div class="row col-xs-10">
   		                        <div class="col-xs-2">
@@ -142,6 +147,11 @@
                           <h2 class="page-header">
                               <i class="fa fa-university"></i> Accounts Screen Settings
                           </h2>
+
+                          <div class="col-xs-3 col-xs-offset-8 page-header-buttons">
+                            <button class="btn btn-lg btn-primary pull-right save-button">Save</button>
+                            <button class="btn btn-lg pull-right cancel-button">Cancel</button>
+                          </div>
 
                           <div class="container col-xs-11">
                             <div class="row col-xs-10">
@@ -230,6 +240,11 @@
                           <h2 class="page-header">
                               <i class="fa fa-envelope-o"></i> Budget Screen Settings
                           </h2>
+
+                          <div class="col-xs-3 col-xs-offset-8 page-header-buttons">
+                            <button class="btn btn-lg btn-primary pull-right save-button">Save</button>
+                            <button class="btn btn-lg pull-right cancel-button">Cancel</button>
+                          </div>
 
 
                           <div class="container col-xs-11">

--- a/src/common/options.html
+++ b/src/common/options.html
@@ -431,8 +431,8 @@
                         </div>
 
                         <div class="col-xs-3 col-xs-offset-8">
-                          <button id="save" class="btn btn-lg btn-primary pull-right">Save</button>
-                          <button id="cancel" class="btn btn-lg pull-right">Cancel</button>
+                          <button class="btn btn-lg btn-primary pull-right save-button">Save</button>
+                          <button class="btn btn-lg pull-right cancel-button">Cancel</button>
                         </div>
 
 

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -152,8 +152,8 @@ KangoAPI.onReady(function() {
     $('#accountsMenuItem').click(function(e) { loadPanel('accounts'); e.preventDefault(); });
     $('#budgetMenuItem').click(function(e) { loadPanel('budget'); e.preventDefault(); });
 
-    $('#save').click(saveOptions);
-    $('#cancel').click(function() {
+    $('.save-button').click(saveOptions);
+    $('.cancel-button').click(function() {
       KangoAPI.closeWindow();
     });
   }, 100);


### PR DESCRIPTION
The existing location of the save and cancel buttons had them buried under a very long list of options. Now there is a set at the top of the screen that is immediately evident and works the same as the original
set.

Oh, I should note that the confirmation message is now fixed to the top of the screen, regardless of page position.