### PR TITLE
Added disctinct style for category titles when progress bar is enabled

### DIFF
--- a/src/common/main.js
+++ b/src/common/main.js
@@ -153,6 +153,10 @@ if (kango.storage.getItem('swapClearedFlagged')) {
   injectScript('res/features/swap-cleared-flagged/main.js');
 }
 
+if (kango.storage.getItem('budgetProgressBars') > 0) {
+  injectCSS('res/features/budget-progress-bars/main.css');
+}
+
 if (kango.storage.getItem('budgetProgressBars') == 1) {
   injectScript('res/features/budget-progress-bars/goals.js');
 }
@@ -191,7 +195,7 @@ else if (kango.storage.getItem('editButtonPosition') == 2) {
 }
 
 if (kango.storage.getItem('daysOfBuffering')) {
-  daysOfBufferingHistoryLookup = kango.storage.getItem('daysOfBufferingHistoryLookup')
+  daysOfBufferingHistoryLookup = kango.storage.getItem('daysOfBufferingHistoryLookup');
   injectJSString('var daysOfBufferingHistoryLookup = ' + daysOfBufferingHistoryLookup + ';');
   injectCSS('res/features/days-of-buffering/main.css');
   injectScript('res/features/days-of-buffering/main.js');

--- a/src/common/res/features/budget-progress-bars/both.js
+++ b/src/common/res/features/budget-progress-bars/both.js
@@ -67,6 +67,7 @@
 
 		var subCategories = $("ul.is-sub-category");
 		$(subCategories).each(function () {
+			$(this).addClass('goal-progress-both');
 			var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
 			var nameCell = $(this).find("li.budget-table-cell-name")[0];
 			var calculation = getCalculation(subCategoryName);

--- a/src/common/res/features/budget-progress-bars/goals.js
+++ b/src/common/res/features/budget-progress-bars/goals.js
@@ -23,8 +23,8 @@
 				var status = calculation.balance / (calculation.balance + calculation.goalOverallLeft);
 			}
 			else if (calculation.goalTarget > 0) {
-				// Taget by date
-				// or Montly goal
+				// Target by date
+				// or Monthly goal
 				var hasGoal = true;
 				var status = 1 - calculation.goalUnderFunded / calculation.goalTarget;
 			}
@@ -35,6 +35,7 @@
 			}
 
 			if (hasGoal) {
+				$(this).addClass('goal-progress');
 				status = status > 1 ? 1 : status;
 				status = status < 0 ? 0 : status;
 				var percent = Math.round(parseFloat(status)*100);

--- a/src/common/res/features/budget-progress-bars/main.css
+++ b/src/common/res/features/budget-progress-bars/main.css
@@ -1,0 +1,27 @@
+.is-checked.goal-progress .button-truncate {
+  width: 98%;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  border-radius: 12px;
+  background-color: #003440 !important;
+  padding-left: 1em;
+}
+
+.budget-table-row.is-checked.goal-progress {
+  color: black;
+}
+
+.is-checked.goal-progress-both .button-truncate {
+  color: #003440 !important;
+  font-weight: bold;
+
+}
+
+.budget-table-row.is-checked.goal-progress-both {
+  color: #cd8ef5;
+}
+
+.ember-view .ynab-checkbox  {
+  margin-right: 3px;
+}
+

--- a/src/common/res/features/budget-progress-bars/main.css
+++ b/src/common/res/features/budget-progress-bars/main.css
@@ -14,7 +14,6 @@
 .is-checked.goal-progress-both .button-truncate {
   color: #003440 !important;
   font-weight: bold;
-
 }
 
 .budget-table-row.is-checked.goal-progress-both {
@@ -23,5 +22,9 @@
 
 .ember-view .ynab-checkbox  {
   margin-right: 3px;
+}
+
+.budget-table-row.is-sub-category.is-checked > .budget-table-cell-available .zero {
+  color: black !important;
 }
 

--- a/src/common/res/features/budget-progress-bars/pacing.js
+++ b/src/common/res/features/budget-progress-bars/pacing.js
@@ -32,6 +32,8 @@
 
 		var subCategories = $("ul.is-sub-category");
 		$(subCategories).each(function () {
+			$(this).addClass('goal-progress');
+			
 			var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
 			var calculation = getCalculation(subCategoryName);
 

--- a/src/common/res/features/remove-positive-highlight/main.css
+++ b/src/common/res/features/remove-positive-highlight/main.css
@@ -1,4 +1,5 @@
-.budget-table-row.is-sub-category > .budget-table-cell-available .positive {
+.budget-table-row.is-sub-category > .budget-table-cell-available .positive,
+.budget-table-row.is-sub-category.is-checked.goal-progress > .budget-table-cell-available .positive {
 	background-color: transparent;
 	color: #16a336;
 	font-weight: bold;
@@ -13,9 +14,18 @@
 .budget-table-row.is-sub-category > .budget-table-cell-available .zero {
 	background-color: transparent;
 	color: #cfd5d8;
+	font-weight: normal;
+}
+
+.budget-table-row.is-sub-category.is-checked.goal-progress > .budget-table-cell-available .positive
+{
+	color: #16a336;
+	font-weight: bold;
 }
 
 .budget-table-row.is-sub-category.is-checked > .budget-table-cell-available .positive,
 .budget-table-row.is-sub-category.is-checked > .budget-table-cell-available .zero {
 	color: #fff;
 }
+
+


### PR DESCRIPTION
Increased visibility of selected categories when either of the 3 progress bar options are enabled by adding bubbled highlight behind category titles.

http://i.imgur.com/NILd0Vo.png

Option number 3 (Both) was quite challenging, so it could be improved, but it works.

