### PR TITLE
Taking advantage of mutationObserver to fix split transactions toggle

### DIFF
--- a/src/common/main.js
+++ b/src/common/main.js
@@ -128,6 +128,7 @@ if (kango.storage.getItem('moveMoneyAutocomplete')) {
 }
 
 if (kango.storage.getItem('toggleSplits')) {
+  injectCSS('res/features/toggle-splits/main.css')
   injectScript('res/features/toggle-splits/main.js');
 }
 

--- a/src/common/res/features/shared/feedChanges.js
+++ b/src/common/res/features/shared/feedChanges.js
@@ -10,6 +10,9 @@
       if ( ynabToolKit.insertPacingColumns ){
         ynabToolKit.insertPacingColumns.observe(digest);
       }
+      if ( ynabToolKit.toggleSplits ){
+    	  ynabToolKit.toggleSplits.observe(digest);
+      }
 
     };
 

--- a/src/common/res/features/toggle-splits/main.css
+++ b/src/common/res/features/toggle-splits/main.css
@@ -1,0 +1,3 @@
+.split-transaction {
+  font-weight: bold;
+}

--- a/src/common/res/features/toggle-splits/main.js
+++ b/src/common/res/features/toggle-splits/main.js
@@ -1,19 +1,60 @@
-(function ynab_enhanced_toggle_splits() {
-  if (typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined') {
+(function poll() { 
+  // Waits until an external function gives us the all clear that we can run (at /shared/main.js)
+  if ( typeof ynabToolKit !== "undefined"  && ynabToolKit.actOnChangeInit === true ) {
+  
+    ynabToolKit.toggleSplits = new function()  { // Keep feature functions contained within this
+        
+      this.setting = 'init',
+      
+      this.invoke = function() { 
+      
+        if ( !$('#toggleSplits').length ) {
+           var toggleButton = "<button id=\"toggleSplits\" class=\"ember-view button\"><i class=\"ember-view flaticon stroke right\"></i><i class=\"ember-view flaticon stroke down\"></i> Toggle Splits </button>" 
+           $(toggleButton).insertAfter(".accounts-toolbar .undo-redo-container");
+          
+          $(".accounts-toolbar-left").find("#toggleSplits").click(function() {
+            if ( ynabToolKit.toggleSplits.setting === 'hide' ) {
+             ynabToolKit.toggleSplits.setting = 'show'; // invert setting
+             $(".ynab-grid-body-sub").show();
+            } else {
+               ynabToolKit.toggleSplits.setting = 'hide';
+               $(".ynab-grid-body-sub").hide();
+            }
+            
+            $("#toggleSplits > i").toggle();
+          });
+        }
+          
+        // default the right arrow to hidden
+        if ( ynabToolKit.toggleSplits.setting === 'init' || ynabToolKit.toggleSplits.setting === 'hide' ) {
+          $("#toggleSplits > .down").hide();
+          $(".ynab-grid-body-sub").hide();
+          ynabToolKit.toggleSplits.setting = 'hide';      
+        } else {
+          $(".ynab-grid-body-sub").show();
+        }
+        
+        $(".ynab-grid-cell-subCategoryName[title^='Split']").each(function() {
+          $(this).html(
+            $(this).html().replace(/Split/g, '<span class="split-transaction">Split</span>')
+          );
+        });
+      },
+      
+      this.observe = function(digest) {
+      
+        for ( var i = 0; i < digest.length; i++ ) {
+          // We found Account transactions rows
+          if ($(digest[i]).hasClass('ynab-grid-body')) {
+            ynabToolKit.toggleSplits.invoke();
+            break;
+          }
+        }
+          
+      }
+    };
 
-    if ($(".undo-redo-container").length && !$('#toggleSplits').length) {
-      var toggleButton = "<button id=\"toggleSplits\" class=\"ember-view button\"><i class=\"ember-view flaticon stroke down\"></i><i class=\"ember-view flaticon stroke right\"></i> Toggle Splits </button>"
-      $(toggleButton).insertAfter(".accounts-toolbar .undo-redo-container");
-
-      // default the right arrow to hidden
-      $("#toggleSplits > .right").hide();
-
-      $("#toggleSplits").bind("click", function() {
-        $(".ynab-grid-body-sub").toggle();
-        $("#toggleSplits > i").toggle();
-      });
-    }
-  }
-
-  setTimeout(ynab_enhanced_toggle_splits, 250);
-})()
+  } else {
+    setTimeout(poll, 250);
+  }   
+})();


### PR DESCRIPTION
This is related to issue #27 and now applies a consistent toggle on split transactions that remains when the user scrolls the page.

I also added a bit of styling to split transaction parent so it's noticeable in a crowd of transactions.