### PR TITLE
Now using async process to load and save options with promises.

### DIFF
--- a/src/common/options.css
+++ b/src/common/options.css
@@ -2,6 +2,13 @@ body {
   min-width: 900px;
 }
 
+/* Start the whole page hidden, then we'll show it with JS once
+   everything has loaded. The page is async, and we don't want to show
+   it until it's ready. */
+#wrapper {
+  display: none;
+}
+
 .navbar-header {
   width: 100%;
 }

--- a/src/common/options.html
+++ b/src/common/options.html
@@ -16,7 +16,7 @@
     <div id="wrapper">
         <nav class="navbar navbar-default top-navbar" role="navigation">
             <div class="navbar-header">
-                <img src="#" id="logo" />
+                <img src="#" id="logo" alt="Tookit for YNAB" />
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".sidebar-collapse">
                     <span class="sr-only">Toggle navigation</span>
                     <span class="icon-bar"></span>
@@ -214,7 +214,7 @@
                           </div>
 
                           <!-- Kevin: Removing Transfer jump until it scrolls to the correct part of the grid
-                                      even if it isn't visible.
+                                      even if it isn't visible. -->
                           <!--div class="container col-xs-11">
                             <div class="row col-xs-10">
                               <div class="col-xs-2">

--- a/src/common/options.js
+++ b/src/common/options.js
@@ -1,24 +1,58 @@
+function getKangoSetting(settingName) {
+
+  return new Promise(function(resolve, reject) {
+    kango.invokeAsync('kango.storage.getItem', settingName, function(data) {
+      resolve(data);
+    });
+  });
+}
+
+function setKangoSetting(settingName, data) {
+  return new Promise(function(resolve, reject) {
+    kango.invokeAsync('kango.storage.setItem', settingName, data, function(data) {
+      resolve("success");
+    });
+  });
+}
+
+function getKangoStorageKeys() {
+  return new Promise(function(resolve, reject) {
+    kango.invokeAsync('kango.storage.getKeys', function(keys) {
+      resolve(keys);
+    });
+  });
+}
+
 function ensureDefaultsAreSet() {
-  var storedKeys = kango.storage.getKeys();
+  return new Promise(function(resolve, reject) {
+    getKangoStorageKeys().then(function(storedKeys) {
 
-  if (storedKeys.indexOf('collapseExpandBudgetGroups') < 0) {
-    kango.storage.setItem('collapseExpandBudgetGroups', true);
-  }
+      var promises = [];
 
-  if (storedKeys.indexOf('enableRetroCalculator') < 0) {
-    kango.storage.setItem('enableRetroCalculator', true);
-  }
+      if (storedKeys.indexOf('collapseExpandBudgetGroups') < 0) {
+        promises.push(setKangoSetting('collapseExpandBudgetGroups', true));
+      }
 
-  if (storedKeys.indexOf('removeZeroCategories') < 0) {
-    kango.storage.setItem('removeZeroCategories', true);
-  }
+      if (storedKeys.indexOf('enableRetroCalculator') < 0) {
+        promises.push(setKangoSetting('enableRetroCalculator', true));
+      }
+
+      if (storedKeys.indexOf('removeZeroCategories') < 0) {
+        promises.push(setKangoSetting('removeZeroCategories', true));
+      }
+
+      Promise.all(promises).then(function() {
+        resolve();
+      });
+    });
+  });
 }
 
 function saveCheckboxOption(elementId) {
   var element = document.getElementById(elementId);
 
   if (element) {
-    kango.storage.setItem(elementId, element.checked);
+    return setKangoSetting(elementId, element.checked);
   } else {
     console.log("WARNING: Tried to saveCheckboxOption but couldn't find element " + elementId + " on the page.");
   }
@@ -28,109 +62,145 @@ function saveSelectOption(elementId) {
   var select = document.getElementById(elementId);
 
   if (select) {
-    kango.storage.setItem(elementId, select.options[select.selectedIndex].value);
+    return setKangoSetting(elementId, select.options[select.selectedIndex].value);
   } else {
     console.log("WARNING: Tried to saveSelectOption but couldn't find element " + elementId + " on the page.");
   }
 }
 
 function restoreCheckboxOption(elementId) {
-  var element = document.getElementById(elementId);
+  return new Promise(function(resolve, reject) {
+    var element = document.getElementById(elementId);
 
-  if (element) {
-    element.checked = kango.storage.getItem(elementId);
-  } else {
-    console.log("WARNING: Tried to restoreCheckboxOption but couldn't find element " + elementId + " on the page.");
-  }
+    if (element) {
+      getKangoSetting(elementId).then(function(value) {
+        element.checked = value;
+
+        resolve();
+      });
+
+    } else {
+      console.log("WARNING: Tried to restoreCheckboxOption but couldn't find element " + elementId + " on the page.");
+
+      // We don't actually want to error if the element isn't there, we want execution to continue.
+      // It's a warning, not an error.
+      resolve();
+    }
+  });
 }
 
 function restoreSelectOption(elementId) {
-  var data = kango.storage.getItem(elementId) || 0;
-  var select = document.getElementById(elementId);
+  return new Promise(function(resolve, reject) {
+    var select = document.getElementById(elementId);
 
-  if (select) {
-    select.value = data;
-  } else {
-    console.log("WARNING: Tried to restoreSelectOption but couldn't find element " + elementId + " on the page.");
-  }
+    if (select) {
+      getKangoSetting(elementId).then(function(data) {
+        data = data || 0;
+
+        select.value = data;
+
+        resolve();
+      });
+    } else {
+      console.log("WARNING: Tried to restoreSelectOption but couldn't find element " + elementId + " on the page.");
+
+      // We don't actually want to error if the element isn't there, we want execution to continue.
+      // It's a warning, not an error.
+      resolve();
+    }
+  });
+
 }
 
 function saveOptions() {
 
-  saveCheckboxOption('collapseExpandBudgetGroups');
-  saveCheckboxOption('collapseSideMenu');
-  saveCheckboxOption('colourBlindMode');
-  saveCheckboxOption('squareNegativeMode');
-  saveCheckboxOption('hideAOM');
-  saveCheckboxOption('checkCreditBalances');
-  saveCheckboxOption('highlightNegativesNegative');
-  saveCheckboxOption('removePositiveHighlight');
-  saveCheckboxOption('enableRetroCalculator');
-  saveCheckboxOption('removeZeroCategories');
-  saveCheckboxOption('moveMoneyDialog');
-  saveCheckboxOption('pacing');
-  saveCheckboxOption('goalIndicator');
-  saveCheckboxOption('moveMoneyAutocomplete');
-  saveCheckboxOption('daysOfBuffering');
-  saveCheckboxOption('toggleSplits');
-  saveCheckboxOption('accountsSelectedTotal');
-  saveCheckboxOption('changeEnterBehavior');
-  saveCheckboxOption('transferJump');
-  saveCheckboxOption('resizeInspector');
-  saveCheckboxOption('importNotification');
-  saveCheckboxOption('swapClearedFlagged');
-  saveCheckboxOption('warnOnQuickBudget');
+  Promise.all([
+    saveCheckboxOption('collapseExpandBudgetGroups'),
+    saveCheckboxOption('collapseSideMenu'),
+    saveCheckboxOption('colourBlindMode'),
+    saveCheckboxOption('squareNegativeMode'),
+    saveCheckboxOption('hideAOM'),
+    saveCheckboxOption('checkCreditBalances'),
+    saveCheckboxOption('highlightNegativesNegative'),
+    saveCheckboxOption('removePositiveHighlight'),
+    saveCheckboxOption('enableRetroCalculator'),
+    saveCheckboxOption('removeZeroCategories'),
+    saveCheckboxOption('moveMoneyDialog'),
+    saveCheckboxOption('pacing'),
+    saveCheckboxOption('goalIndicator'),
+    saveCheckboxOption('moveMoneyAutocomplete'),
+    saveCheckboxOption('daysOfBuffering'),
+    saveCheckboxOption('toggleSplits'),
+    saveCheckboxOption('accountsSelectedTotal'),
+    saveCheckboxOption('changeEnterBehavior'),
+    saveCheckboxOption('transferJump'),
+    saveCheckboxOption('resizeInspector'),
+    saveCheckboxOption('importNotification'),
+    saveCheckboxOption('swapClearedFlagged'),
+    saveCheckboxOption('warnOnQuickBudget'),
 
-  saveSelectOption('daysOfBufferingHistoryLookup');
-  saveSelectOption('budgetRowsHeight');
-  saveSelectOption('reconciledTextColor');
-  saveSelectOption('categoryActivityPopupWidth');
-  saveSelectOption('accountsDisplayDensity');
-  saveSelectOption('editButtonPosition');
-  saveSelectOption('budgetProgressBars');
+    saveSelectOption('daysOfBufferingHistoryLookup'),
+    saveSelectOption('budgetRowsHeight'),
+    saveSelectOption('reconciledTextColor'),
+    saveSelectOption('categoryActivityPopupWidth'),
+    saveSelectOption('accountsDisplayDensity'),
+    saveSelectOption('editButtonPosition'),
+    saveSelectOption('budgetProgressBars')
+  ]).then(function() {
 
-  $('#settingsSaved').fadeIn()
-                     .delay(1500)
-                     .fadeOut();
+    $('#settingsSaved').fadeIn()
+                       .delay(1500)
+                       .fadeOut();
+
+  });
 }
 
 // Restores select box and checkbox state using the preferences
 // stored in chrome.storage.
 function restoreOptions() {
 
-  ensureDefaultsAreSet();
+  return new Promise(function (resolve, reject) {
+    ensureDefaultsAreSet().then(function() {
 
-  restoreCheckboxOption('collapseExpandBudgetGroups');
-  restoreCheckboxOption('collapseSideMenu');
-  restoreCheckboxOption('colourBlindMode');
-  restoreCheckboxOption('squareNegativeMode');
-  restoreCheckboxOption('hideAOM');
-  restoreCheckboxOption('checkCreditBalances');
-  restoreCheckboxOption('highlightNegativesNegative');
-  restoreCheckboxOption('removePositiveHighlight');
-  restoreCheckboxOption('enableRetroCalculator');
-  restoreCheckboxOption('removeZeroCategories');
-  restoreCheckboxOption('moveMoneyDialog');
-  restoreCheckboxOption('pacing');
-  restoreCheckboxOption('goalIndicator');
-  restoreCheckboxOption('moveMoneyAutocomplete');
-  restoreCheckboxOption('daysOfBuffering');
-  restoreCheckboxOption('toggleSplits');
-  restoreCheckboxOption('accountsSelectedTotal');
-  restoreCheckboxOption('changeEnterBehavior');
-  restoreCheckboxOption('transferJump');
-  restoreCheckboxOption('resizeInspector');
-  restoreCheckboxOption('importNotification');
-  restoreCheckboxOption('swapClearedFlagged');
-  restoreCheckboxOption('warnOnQuickBudget');
+      Promise.all([
+        restoreCheckboxOption('collapseExpandBudgetGroups'),
+        restoreCheckboxOption('collapseSideMenu'),
+        restoreCheckboxOption('colourBlindMode'),
+        restoreCheckboxOption('squareNegativeMode'),
+        restoreCheckboxOption('hideAOM'),
+        restoreCheckboxOption('checkCreditBalances'),
+        restoreCheckboxOption('highlightNegativesNegative'),
+        restoreCheckboxOption('removePositiveHighlight'),
+        restoreCheckboxOption('enableRetroCalculator'),
+        restoreCheckboxOption('removeZeroCategories'),
+        restoreCheckboxOption('moveMoneyDialog'),
+        restoreCheckboxOption('pacing'),
+        restoreCheckboxOption('goalIndicator'),
+        restoreCheckboxOption('moveMoneyAutocomplete'),
+        restoreCheckboxOption('daysOfBuffering'),
+        restoreCheckboxOption('toggleSplits'),
+        restoreCheckboxOption('accountsSelectedTotal'),
+        restoreCheckboxOption('changeEnterBehavior'),
+        restoreCheckboxOption('transferJump'),
+        restoreCheckboxOption('resizeInspector'),
+        restoreCheckboxOption('importNotification'),
+        restoreCheckboxOption('swapClearedFlagged'),
+        restoreCheckboxOption('warnOnQuickBudget'),
 
-  restoreSelectOption('daysOfBufferingHistoryLookup');
-  restoreSelectOption('budgetRowsHeight');
-  restoreSelectOption('reconciledTextColor');
-  restoreSelectOption('categoryActivityPopupWidth');
-  restoreSelectOption('accountsDisplayDensity');
-  restoreSelectOption('editButtonPosition');
-  restoreSelectOption('budgetProgressBars');
+        restoreSelectOption('daysOfBufferingHistoryLookup'),
+        restoreSelectOption('budgetRowsHeight'),
+        restoreSelectOption('reconciledTextColor'),
+        restoreSelectOption('categoryActivityPopupWidth'),
+        restoreSelectOption('accountsDisplayDensity'),
+        restoreSelectOption('editButtonPosition'),
+        restoreSelectOption('budgetProgressBars')
+      ]).then(function() {
+        resolve();
+      }, function() {
+        console.log("Ensure defaults are set failed.");
+      });
+    });
+  });
 }
 
 function loadPanel(panel, animated) {
@@ -155,24 +225,23 @@ function loadPanel(panel, animated) {
 }
 
 KangoAPI.onReady(function() {
-  setTimeout(function() {
-    restoreOptions();
+  // Set the logo.
+  kango.invokeAsync('kango.io.getResourceUrl', 'assets/logos/toolkitforynab-logo-200.png', function(data) {
+    $('#logo').attr('src', data);
+  });
 
+  restoreOptions().then(function() {
     $('input:checkbox').bootstrapSwitch();
 
     loadPanel('general', false);
 
-    $('#generalMenuItem').click(function(e) { loadPanel('general'); e.preventDefault(); });
-    $('#accountsMenuItem').click(function(e) { loadPanel('accounts'); e.preventDefault(); });
-    $('#budgetMenuItem').click(function(e) { loadPanel('budget'); e.preventDefault(); });
+    $('#wrapper').fadeIn();
+  });
 
-    $('.save-button').click(saveOptions);
-    $('.cancel-button').click(function() {
-      KangoAPI.closeWindow();
-    });
-  }, 50); // A small setTimeout allows KangoAPI to work without needing to be async
-          // which looks like it'd be hugely painful to implement. The docs say
-          // we should be doing async here, and if it stops working, revisit this decision.
+  $('#generalMenuItem').click(function(e) { loadPanel('general'); e.preventDefault(); });
+  $('#accountsMenuItem').click(function(e) { loadPanel('accounts'); e.preventDefault(); });
+  $('#budgetMenuItem').click(function(e) { loadPanel('budget'); e.preventDefault(); });
 
-  $('#logo').attr('src', kango.io.getResourceUrl('assets/logos/toolkitforynab-logo-200.png'));
+  $('.save-button').click(saveOptions);
+  $('.cancel-button').click(KangoAPI.closeWindow);
 });


### PR DESCRIPTION
Kango docs say that the API is only available async from the options page. Although it works on Chrome and Firefox with direct calls, it doesn't on Safari, so the refactor is necessary to ensure it works across all supported browsers. I was using a setTimeout hack which worked sometimes on Safari, but not all the time. This seems to work more consistently.

I'm doing this via a pull request so people like @Niictar, @egens and @iamnafets see what's going on and why instead of just slamming it into Master with no explanation. :+1: 