### PR TITLE
Fixing timezone issues in calculating selected date

### DIFF
--- a/src/common/res/features/shared/main.js
+++ b/src/common/res/features/shared/main.js
@@ -98,8 +98,8 @@ ynabToolKit.shared = new function() {
         // TODO: There's probably a better way to reference this view, but this works better than DOM scraping which seems to fail in Firefox
         if($('.ember-view .budget-header').length) {
             var headerView = Ember.View.views[$('.ember-view .budget-header').attr("id")];
-            var endOfLastMonth = headerView.get("currentMonth").toNativeDate();
-            return new Date(endOfLastMonth.getFullYear(), endOfLastMonth.getMonth()+1, 1);
+            var selectedMonthUTC = headerView.get("currentMonth").toNativeDate();
+            return new Date(selectedMonthUTC.getUTCFullYear(), selectedMonthUTC.getUTCMonth(), 1);
         } else {
             return null;
         }


### PR DESCRIPTION
Native date returns a date with a timezone, but headerView's "currentMonth" is in UTC. This results in discrepancies between timezones like @egens +3 and my -8.

This method should now return the correct date with the local timezone.

Conversation here: https://github.com/blargity/toolkit-for-ynab/pull/128