### PR TITLE
Complete - Refactor feature dependency out of actOnChange

### DIFF
--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -17,7 +17,7 @@
         if (ynabToolKit.debugNodes) {
           console.log('MODIFIED NODES');
         }
-        
+
         ynabToolKit.changedNodes = new Set();
 
         mutations.forEach(function(mutation) {
@@ -49,17 +49,10 @@
               ynabToolKit.updateInspectorColours();
           }
         }
-        
-        // The user has switched screens
-        if (ynabToolKit.changedNodes.has('layout')) {
-          if ( ynabToolKit.options.resizeInspector ){
-            ynabToolKit.resizeInspector();
-          }
-        }
 
         // The user has returned back to the budget screen
         if (ynabToolKit.changedNodes.has('navlink-budget') && ynabToolKit.changedNodes.has('active')) {
-        
+
           if ( ynabToolKit.options.budgetProgressBars ){
             ynabToolKit.budgetProgressBars();
           }

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -32,7 +32,7 @@
 
             try {
               nodeClasses = new Set($node[0].className.split(' '));
-            } catch(err) { var ynabToolKit.debugNodes.errors = err }
+            } catch(err) {/* ignore */}
 
             ynabToolKit.changedNodes = new Set([...ynabToolKit.changedNodes, ...nodeClasses]);
 
@@ -47,9 +47,6 @@
         // The user has returned back to the budget screen
         if (ynabToolKit.changedNodes.has('navlink-budget') && ynabToolKit.changedNodes.has('active')) {
 
-          if ( ynabToolKit.options.budgetProgressBars ){
-            ynabToolKit.budgetProgressBars();
-          }
           if ( ynabToolKit.options.goalIndicator ){
             ynabToolKit.goalIndicator();
           }

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -76,9 +76,6 @@
           if ( ynabToolKit.options.warnOnQuickBudget ){
             ynabToolKit.warnOnQuickBudget();
           }
-          if ( ynabToolKit.options.checkCreditBalances ){
-              ynabToolKit.checkCreditBalances();
-          }
 
         }
 

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -43,13 +43,6 @@
           console.log('###')
         }
 
-        // Changes are detected in the category balances
-        if (ynabToolKit.changedNodes.has('budget-table-cell-available-div')) {
-          if ( ynabToolKit.options.checkCreditBalances ||  ynabToolKit.options.highlightNegativesNegative ) {
-              ynabToolKit.updateInspectorColours();
-          }
-        }
-
         // The user has returned back to the budget screen
         if (ynabToolKit.changedNodes.has('navlink-budget') && ynabToolKit.changedNodes.has('active')) {
 
@@ -73,15 +66,6 @@
           }
           if (ynabToolKit.options.moveMoneyAutocomplete) {
             ynabToolKit.moveMoneyAutocomplete();
-          }
-
-        }
-
-        // User has selected a specific sub-category
-        if (ynabToolKit.changedNodes.has('is-sub-category') && ynabToolKit.changedNodes.has('is-checked')) {
-
-          if ( ynabToolKit.options.checkCreditBalances ||  ynabToolKit.options.highlightNegativesNegative ) {
-            ynabToolKit.updateInspectorColours();
           }
 
         }

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -1,3 +1,6 @@
+// Building a new feature that uses MutationObserver? You don't need to modify this file
+// Instead of adding conditionals to this file try the example from /shared/example.js
+
 (function poll() {
   if (ynabToolKit.pageReady === true && typeof ynabToolKit.shared.feedChanges !== 'undefined') {
 

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -49,9 +49,6 @@
         // The user has returned back to the budget screen
         if (ynabToolKit.changedNodes.has('navlink-budget') && ynabToolKit.changedNodes.has('active')) {
 
-          if ( ynabToolKit.options.goalIndicator ){
-            ynabToolKit.goalIndicator();
-          }
           if ( ynabToolKit.options.warnOnQuickBudget ){
             ynabToolKit.warnOnQuickBudget();
           }

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -61,9 +61,6 @@
         // We found a modal pop-up
         if (ynabToolKit.changedNodes.has('options-shown')) {
 
-          if (ynabToolKit.options.removeZeroCategories) {
-            ynabToolKit.removeZeroCategories();
-          }
           if (ynabToolKit.options.moveMoneyAutocomplete) {
             ynabToolKit.moveMoneyAutocomplete();
           }

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -32,7 +32,9 @@
 
             try {
               nodeClasses = new Set($node[0].className.split(' '));
-            } catch(err) {/* ignore */}
+            } catch(err) {
+              ynabToolKit.debugNodes.errors = err
+            }
 
             ynabToolKit.changedNodes = new Set([...ynabToolKit.changedNodes, ...nodeClasses]);
 

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -46,24 +46,6 @@
           console.log('###')
         }
 
-        // The user has returned back to the budget screen
-        if (ynabToolKit.changedNodes.has('navlink-budget') && ynabToolKit.changedNodes.has('active')) {
-
-          if ( ynabToolKit.options.warnOnQuickBudget ){
-            ynabToolKit.warnOnQuickBudget();
-          }
-
-        }
-
-        // The user has changed their budget row selection
-        if (ynabToolKit.changedNodes.has('budget-inspector')) {
-
-          if ( ynabToolKit.options.warnOnQuickBudget ){
-            ynabToolKit.warnOnQuickBudget();
-          }
-
-        }
-
         // Now we are ready to feed the change digest to the
         // automatically setup feedChanges file/function
         ynabToolKit.shared.feedChanges(ynabToolKit.changedNodes);

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -79,9 +79,6 @@
           if ( ynabToolKit.options.checkCreditBalances ){
               ynabToolKit.checkCreditBalances();
           }
-          if ( ynabToolKit.options.highlightNegativesNegative ){
-            ynabToolKit.highlightNegativesNegative();
-          }
 
         }
 

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -58,15 +58,6 @@
 
         }
 
-        // We found a modal pop-up
-        if (ynabToolKit.changedNodes.has('options-shown')) {
-
-          if (ynabToolKit.options.moveMoneyAutocomplete) {
-            ynabToolKit.moveMoneyAutocomplete();
-          }
-
-        }
-
         // The user has changed their budget row selection
         if (ynabToolKit.changedNodes.has('budget-inspector')) {
 

--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -30,9 +30,10 @@
           $nodes.each(function() {
             var $node = $(this);
 
-            if ( typeof $node[0].className !== 'undefined' ) {
-            	nodeClasses = new Set($node[0].className.split(' '));
-            }
+            try {
+              nodeClasses = new Set($node[0].className.split(' '));
+            } catch(err) { var ynabToolKit.debugNodes.errors = err }
+
             ynabToolKit.changedNodes = new Set([...ynabToolKit.changedNodes, ...nodeClasses]);
 
           }); // each node mutation event

--- a/src/common/res/features/budget-progress-bars/both.js
+++ b/src/common/res/features/budget-progress-bars/both.js
@@ -1,112 +1,122 @@
 // TODO: Needs refactoring because of copy-paster from pacing.js and goal.js
-(function poll() { 
+(function poll() {
   // Waits until an external function gives us the all clear that we can run (at /shared/main.js)
   if ( typeof ynabToolKit !== "undefined"  && ynabToolKit.pageReady === true ) {
-  
+
     ynabToolKit.options.budgetProgressBars = true;
-    ynabToolKit.budgetProgressBars = function ()  { // Keep feature functions contained within this
-    	var entityManager = ynab.YNABSharedLib.defaultInstance.entityManager;
+    ynabToolKit.budgetProgressBars = new function ()  { // Keep feature functions contained within this
+      var entityManager = ynab.YNABSharedLib.defaultInstance.entityManager;
 
-	   	function getCalculation(subCategoryName) {
-    		var crazyInternalId = "mcbc/" + ynabToolKit.shared.parseSelectedMonth().yyyymm() + "/" + entityManager.getSubCategoryByName(subCategoryName).getEntityId();
-			var calculation = entityManager.getMonthlySubCategoryBudgetCalculationById(crazyInternalId);
-			return calculation;
-    	}
+      this.invoke = function() {
+        function getCalculation(subCategoryName) {
+          var crazyInternalId = "mcbc/" + ynabToolKit.shared.parseSelectedMonth().yyyymm() + "/" + entityManager.getSubCategoryByName(subCategoryName).getEntityId();
+        var calculation = entityManager.getMonthlySubCategoryBudgetCalculationById(crazyInternalId);
+        return calculation;
+        }
 
-		var subCategories = $("ul.is-sub-category");
-		$(subCategories).each(function () {
-			var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
-			calculation = getCalculation(subCategoryName);
+        var subCategories = $("ul.is-sub-category");
+        $(subCategories).each(function () {
+        var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
+        calculation = getCalculation(subCategoryName);
 
-			if (calculation.goalExpectedCompletion > 0) {
-				// Target total goal
-				var hasGoal = true;
-				var status = calculation.balance / (calculation.balance + calculation.goalOverallLeft);
-			}
-			else if (calculation.goalTarget > 0) {
-				// Taget by date
-				// or Montly goal
-				var hasGoal = true;
-				var status = 1 - calculation.goalUnderFunded / calculation.goalTarget;
-			}
-			else if (calculation.upcomingTransactions < 0) {
-				// Upcoming transactions "goal"
-				var hasGoal = true;
-				var status = - calculation.balance / calculation.upcomingTransactions;
-			}
+        if (calculation.goalExpectedCompletion > 0) {
+          // Target total goal
+          var hasGoal = true;
+          var status = calculation.balance / (calculation.balance + calculation.goalOverallLeft);
+        }
+        else if (calculation.goalTarget > 0) {
+          // Taget by date
+          // or Montly goal
+          var hasGoal = true;
+          var status = 1 - calculation.goalUnderFunded / calculation.goalTarget;
+        }
+        else if (calculation.upcomingTransactions < 0) {
+          // Upcoming transactions "goal"
+          var hasGoal = true;
+          var status = - calculation.balance / calculation.upcomingTransactions;
+        }
 
-			var budgetedCell = $(this).find("li.budget-table-cell-budgeted")[0];
-			if (hasGoal) {
-				status = status > 1 ? 1 : status;
-				status = status < 0 ? 0 : status;
-				var percent = Math.round(parseFloat(status)*100);
-				budgetedCell.style.background = "linear-gradient(to right, rgba(22, 163, 54, 0.3) " + percent + "%, white " + percent+ "%)";
-			}
-			else {
-				budgetedCell.removeAttribute("style");
-			}
-		})
+        var budgetedCell = $(this).find("li.budget-table-cell-budgeted")[0];
+        if (hasGoal) {
+          status = status > 1 ? 1 : status;
+          status = status < 0 ? 0 : status;
+          var percent = Math.round(parseFloat(status)*100);
+          budgetedCell.style.background = "linear-gradient(to right, rgba(22, 163, 54, 0.3) " + percent + "%, white " + percent+ "%)";
+        }
+        else {
+          budgetedCell.removeAttribute("style");
+        }
+        })
 
-		// Takes N colors and N-1 sorted points from (0, 1) to make color1|color2|color3 bg style.
-		function generateProgressBarStyle(colors, points) {
-			points.unshift(0);
-			points.push(1);
-			var pointsPercent = Array.from(points, (p) => p*100);
-			style = "linear-gradient(to right, ";
-			for (var i = 0; i < colors.length; i++) {
-				style += colors[i] + " " + pointsPercent[i] + "%, ";
-				style += colors[i] + " " + pointsPercent[i + 1] + "%";
-				style += (i + 1 == colors.length) ? ")" : ", ";
-				}
-				return style;
-		}
+        // Takes N colors and N-1 sorted points from (0, 1) to make color1|color2|color3 bg style.
+        function generateProgressBarStyle(colors, points) {
+        points.unshift(0);
+        points.push(1);
+        var pointsPercent = Array.from(points, (p) => p*100);
+        style = "linear-gradient(to right, ";
+        for (var i = 0; i < colors.length; i++) {
+          style += colors[i] + " " + pointsPercent[i] + "%, ";
+          style += colors[i] + " " + pointsPercent[i + 1] + "%";
+          style += (i + 1 == colors.length) ? ")" : ", ";
+          }
+          return style;
+        }
 
-		var date = new Date();
-		var monthProgress = new Date().getDate() / new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
-		var s = 0.005; // Current month progress indicator width
+        var date = new Date();
+        var monthProgress = new Date().getDate() / new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+        var s = 0.005; // Current month progress indicator width
 
-		var subCategories = $("ul.is-sub-category");
-		$(subCategories).each(function () {
-			$(this).addClass('goal-progress-both');
-			var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
-			var nameCell = $(this).find("li.budget-table-cell-name")[0];
-			var calculation = getCalculation(subCategoryName);
+        var subCategories = $("ul.is-sub-category");
+        $(subCategories).each(function () {
+        $(this).addClass('goal-progress-both');
+        var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
+        var nameCell = $(this).find("li.budget-table-cell-name")[0];
+        var calculation = getCalculation(subCategoryName);
 
-			var budgeted = calculation.balance - calculation.budgetedCashOutflows - calculation.budgetedCreditOutflows;
-			var available = calculation.balance;
+        var budgeted = calculation.balance - calculation.budgetedCashOutflows - calculation.budgetedCreditOutflows;
+        var available = calculation.balance;
 
-			if (budgeted > 0) {
-				var pacing = (budgeted - available) / budgeted;
-				if (monthProgress > pacing) {
-					nameCell.style.background = generateProgressBarStyle(
-						["#c0e2e9", "white", "#CFD5D8", "white"],
-						[pacing, monthProgress - s, monthProgress]);
-				}
-				else {
-					nameCell.style.background = generateProgressBarStyle(
-						["#c0e2e9", "#CFD5D8", "#c0e2e9", "white"],
-						[monthProgress - s, monthProgress, pacing]);
-				}
-			}
-			else {
-				nameCell.style.background = generateProgressBarStyle(
-						["white", "#CFD5D8", "white"],
-						[monthProgress - s, monthProgress]);
-			}
-		})
+        if (budgeted > 0) {
+          var pacing = (budgeted - available) / budgeted;
+          if (monthProgress > pacing) {
+            nameCell.style.background = generateProgressBarStyle(
+              ["#c0e2e9", "white", "#CFD5D8", "white"],
+              [pacing, monthProgress - s, monthProgress]);
+          }
+          else {
+            nameCell.style.background = generateProgressBarStyle(
+              ["#c0e2e9", "#CFD5D8", "#c0e2e9", "white"],
+              [monthProgress - s, monthProgress, pacing]);
+          }
+        }
+        else {
+          nameCell.style.background = generateProgressBarStyle(
+              ["white", "#CFD5D8", "white"],
+              [monthProgress - s, monthProgress]);
+        }
+        });
 
-		var masterCategories = $("ul.is-master-category");
-		$(masterCategories).each(function () {
-			var nameCell = $(this).find("li.budget-table-cell-name")[0];
-			nameCell.style.background = generateProgressBarStyle(
-						["#E5F5F9", "#CFD5D8", "#E5F5F9"],
-						[monthProgress - s, monthProgress]);
-		})
-     
+        var masterCategories = $("ul.is-master-category");
+        $(masterCategories).each(function () {
+          var nameCell = $(this).find("li.budget-table-cell-name")[0];
+          nameCell.style.background = generateProgressBarStyle(
+                ["#E5F5F9", "#CFD5D8", "#E5F5F9"],
+                [monthProgress - s, monthProgress]);
+        });
+      },
+
+      this.observe = function(changedNodes) {
+
+      if (changedNodes.has('navlink-budget') && changedNodes.has('active')) {
+          // The user has returned back to the budget screen
+          ynabToolKit.budgetProgressBars.invoke();
+        }
+      };
+
     }; // Keep feature functions contained within this
-    ynabToolKit.budgetProgressBars(); // Run once and activate setTimeOut()
+    ynabToolKit.budgetProgressBars.invoke(); // Run once and activate setTimeOut()
 
   } else {
-    setTimeout(poll, 250);  
+    setTimeout(poll, 250);
   }
 })();

--- a/src/common/res/features/budget-progress-bars/goals.js
+++ b/src/common/res/features/budget-progress-bars/goals.js
@@ -1,55 +1,66 @@
-(function poll() { 
+(function poll() {
   // Waits until an external function gives us the all clear that we can run (at /shared/main.js)
   if ( typeof ynabToolKit !== "undefined"  && ynabToolKit.pageReady === true ) {
-  
-    ynabToolKit.budgetProgressBars = function ()  { // Keep feature functions contained within this
-    	var entityManager = ynab.YNABSharedLib.defaultInstance.entityManager;
 
-	   	function getCalculation(subCategoryName) {
-    		var crazyInternalId = "mcbc/" + ynabToolKit.shared.parseSelectedMonth().yyyymm() + "/" + entityManager.getSubCategoryByName(subCategoryName).getEntityId();
-			var calculation = entityManager.getMonthlySubCategoryBudgetCalculationById(crazyInternalId);
-			return calculation;
-    	}
+    ynabToolKit.budgetProgressBars = new function ()  { // Keep feature functions contained within this
 
-		var subCategories = $("ul.is-sub-category");
-		$(subCategories).each(function () {
-			var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
-			calculation = getCalculation(subCategoryName);
+    var entityManager = ynab.YNABSharedLib.defaultInstance.entityManager;
 
-			if (calculation.goalExpectedCompletion > 0) { 
-				// Target total goal
-				var hasGoal = true;
-				var status = calculation.balance / (calculation.balance + calculation.goalOverallLeft);
-			}
-			else if (calculation.goalTarget > 0) {
-				// Target by date
-				// or Monthly goal
-				var hasGoal = true;
-				var status = 1 - calculation.goalUnderFunded / calculation.goalTarget;
-			}
-			else if (calculation.upcomingTransactions < 0) {
-				// Upcoming transactions "goal"
-				var hasGoal = true;
-				var status = - calculation.balance / calculation.upcomingTransactions;
-			}
+    function getCalculation(subCategoryName) {
+      var crazyInternalId = "mcbc/" + ynabToolKit.shared.parseSelectedMonth().yyyymm() + "/" + entityManager.getSubCategoryByName(subCategoryName).getEntityId();
+    var calculation = entityManager.getMonthlySubCategoryBudgetCalculationById(crazyInternalId);
+    return calculation;
+    }
 
-			if (hasGoal) {
-				$(this).addClass('goal-progress');
-				status = status > 1 ? 1 : status;
-				status = status < 0 ? 0 : status;
-				var percent = Math.round(parseFloat(status)*100);
-				this.style.background = "linear-gradient(to right, #c1e8c0 " + percent + "%, white " + percent+ "%)";
-			}
-			else {
-				this.removeAttribute("style");
-			}
-		})
-     
+    this.invoke = function() {
+      var subCategories = $("ul.is-sub-category");
+      $(subCategories).each(function () {
+      var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
+      calculation = getCalculation(subCategoryName);
+
+      if (calculation.goalExpectedCompletion > 0) {
+        // Target total goal
+        var hasGoal = true;
+        var status = calculation.balance / (calculation.balance + calculation.goalOverallLeft);
+      }
+      else if (calculation.goalTarget > 0) {
+        // Target by date
+        // or Monthly goal
+        var hasGoal = true;
+        var status = 1 - calculation.goalUnderFunded / calculation.goalTarget;
+      }
+      else if (calculation.upcomingTransactions < 0) {
+        // Upcoming transactions "goal"
+        var hasGoal = true;
+        var status = - calculation.balance / calculation.upcomingTransactions;
+      }
+
+      if (hasGoal) {
+        $(this).addClass('goal-progress');
+        status = status > 1 ? 1 : status;
+        status = status < 0 ? 0 : status;
+        var percent = Math.round(parseFloat(status)*100);
+        this.style.background = "linear-gradient(to right, #c1e8c0 " + percent + "%, white " + percent+ "%)";
+      }
+      else {
+        this.removeAttribute("style");
+      }
+      });
+    },
+
+    this.observe = function(changedNodes) {
+
+      if (changedNodes.has('navlink-budget') && changedNodes.has('active')) {
+          // The user has returned back to the budget screen
+          ynabToolKit.budgetProgressBars.invoke();
+        }
+      };
+
     }; // Keep feature functions contained within this
-    ynabToolKit.budgetProgressBars(); // Run once and activate setTimeOut()
+    ynabToolKit.budgetProgressBars.invoke(); // Run once and activate setTimeOut()
 
   } else {
-    setTimeout(poll, 250);  
+    setTimeout(poll, 250);
   }
 })();
 

--- a/src/common/res/features/budget-progress-bars/pacing.js
+++ b/src/common/res/features/budget-progress-bars/pacing.js
@@ -1,76 +1,88 @@
-(function poll() { 
+(function poll() {
   // Waits until an external function gives us the all clear that we can run (at /shared/main.js)
   if ( typeof ynabToolKit !== "undefined"  && ynabToolKit.pageReady === true ) {
-  
+
     ynabToolKit.options.budgetProgressBars = true;
-    ynabToolKit.budgetProgressBars = function ()  { // Keep feature functions contained within this
-    	var entityManager = ynab.YNABSharedLib.defaultInstance.entityManager;
+    ynabToolKit.budgetProgressBars = new function ()  { // Keep feature functions contained within this
 
-	   	function getCalculation(subCategoryName) {
-    		var crazyInternalId = "mcbc/" + ynabToolKit.shared.parseSelectedMonth().yyyymm() + "/" + entityManager.getSubCategoryByName(subCategoryName).getEntityId();
-			var calculation = entityManager.getMonthlySubCategoryBudgetCalculationById(crazyInternalId);
-			return calculation;
-    	}
+      var entityManager = ynab.YNABSharedLib.defaultInstance.entityManager;
 
-		// Takes N colors and N-1 sorted points from (0, 1) to make color1|color2|color3 bg style.
-		function generateProgressBarStyle(colors, points) {
-			points.unshift(0);
-			points.push(1);
-			var pointsPercent = Array.from(points, (p) => p*100);
-			style = "linear-gradient(to right, ";
-			for (var i = 0; i < colors.length; i++) {
-				style += colors[i] + " " + pointsPercent[i] + "%, ";
-				style += colors[i] + " " + pointsPercent[i + 1] + "%";
-				style += (i + 1 == colors.length) ? ")" : ", ";
-				}
-				return style;
-		}
+      function getCalculation(subCategoryName) {
+        var crazyInternalId = "mcbc/" + ynabToolKit.shared.parseSelectedMonth().yyyymm() + "/" + entityManager.getSubCategoryByName(subCategoryName).getEntityId();
+      var calculation = entityManager.getMonthlySubCategoryBudgetCalculationById(crazyInternalId);
+      return calculation;
+      }
 
-		var date = new Date();
-		var monthProgress = new Date().getDate() / new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
-		var s = 0.005; // Current month progress indicator width
+      // Takes N colors and N-1 sorted points from (0, 1) to make color1|color2|color3 bg style.
+      function generateProgressBarStyle(colors, points) {
+      points.unshift(0);
+      points.push(1);
+      var pointsPercent = Array.from(points, (p) => p*100);
+      style = "linear-gradient(to right, ";
+      for (var i = 0; i < colors.length; i++) {
+        style += colors[i] + " " + pointsPercent[i] + "%, ";
+        style += colors[i] + " " + pointsPercent[i + 1] + "%";
+        style += (i + 1 == colors.length) ? ")" : ", ";
+        }
+        return style;
+      }
 
-		var subCategories = $("ul.is-sub-category");
-		$(subCategories).each(function () {
-			$(this).addClass('goal-progress');
-			
-			var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
-			var calculation = getCalculation(subCategoryName);
+      this.invoke = function() {
 
-	    	var budgeted = calculation.balance - calculation.budgetedCashOutflows - calculation.budgetedCreditOutflows;
-    		var available = calculation.balance;
-    		
-			if (budgeted > 0) {
-				var pacing = (budgeted - available) / budgeted;
-				if (monthProgress > pacing) {
-					this.style.background = generateProgressBarStyle(
-						["#c0e2e9", "white", "#CFD5D8", "white"],
-						[pacing, monthProgress - s, monthProgress]);
-				}
-				else {
-					this.style.background = generateProgressBarStyle(
-						["#c0e2e9", "#CFD5D8", "#c0e2e9", "white"],
-						[monthProgress - s, monthProgress, pacing]);
-				}
-			}
-			else {
-				this.style.background = generateProgressBarStyle(
-						["white", "#CFD5D8", "white"],
-						[monthProgress - s, monthProgress]);
-			}
-		})
+        var date = new Date();
+        var monthProgress = new Date().getDate() / new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+        var s = 0.005; // Current month progress indicator width
 
-		var masterCategories = $("ul.is-master-category");
-		$(masterCategories).each(function () {
-			this.style.background = generateProgressBarStyle(
-						["#E5F5F9", "#CFD5D8", "#E5F5F9"],
-						[monthProgress - s, monthProgress]);
-		})
-     
+        var subCategories = $("ul.is-sub-category");
+        $(subCategories).each(function () {
+        $(this).addClass('goal-progress');
+
+        var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
+        var calculation = getCalculation(subCategoryName);
+
+        var budgeted = calculation.balance - calculation.budgetedCashOutflows - calculation.budgetedCreditOutflows;
+        var available = calculation.balance;
+
+        if (budgeted > 0) {
+          var pacing = (budgeted - available) / budgeted;
+          if (monthProgress > pacing) {
+            this.style.background = generateProgressBarStyle(
+              ["#c0e2e9", "white", "#CFD5D8", "white"],
+              [pacing, monthProgress - s, monthProgress]);
+          }
+          else {
+            this.style.background = generateProgressBarStyle(
+              ["#c0e2e9", "#CFD5D8", "#c0e2e9", "white"],
+              [monthProgress - s, monthProgress, pacing]);
+          }
+        }
+        else {
+          this.style.background = generateProgressBarStyle(
+              ["white", "#CFD5D8", "white"],
+              [monthProgress - s, monthProgress]);
+        }
+        })
+
+        var masterCategories = $("ul.is-master-category");
+        $(masterCategories).each(function () {
+          this.style.background = generateProgressBarStyle(
+                ["#E5F5F9", "#CFD5D8", "#E5F5F9"],
+                [monthProgress - s, monthProgress]);
+        })
+      },
+
+      this.observe = function(changedNodes) {
+
+      if (changedNodes.has('navlink-budget') && changedNodes.has('active')) {
+          // The user has returned back to the budget screen
+          ynabToolKit.budgetProgressBars.invoke();
+        }
+      };
+
     }; // Keep feature functions contained within this
-    ynabToolKit.budgetProgressBars(); // Run once and activate setTimeOut()
+    ynabToolKit.budgetProgressBars.invoke(); // Run once and activate setTimeOut()
 
   } else {
-    setTimeout(poll, 250);  
+    setTimeout(poll, 250);
   }
 })();

--- a/src/common/res/features/check-credit-balances/main.js
+++ b/src/common/res/features/check-credit-balances/main.js
@@ -1,52 +1,58 @@
 (function poll() {
    if ( typeof ynabToolKit !== "undefined" && ynabToolKit.actOnChangeInit === true ) {
-   		
-   	ynabToolKit.checkCreditBalances = function ()  {
-         
-            var debtPaymentCategories = $('.is-debt-payment-category.is-sub-category');
-            var accountName = {};
-            var accountBalance = {};
-            var accountMatch = {};
-      
-            $(debtPaymentCategories).each(function() {
-               accountName = $(this).find('.budget-table-cell-name div.button-truncate').prop('title')
-      
-               var categoryBalance = $(this).find('.budget-table-cell-available-div .user-data.currency').html();
-               categoryBalance = Number(categoryBalance.replace(/[^\d.-]/g, ''));
-      
-               $('.nav-account-row').each(function() {
-      
-                  if ( $(this).find('.nav-account-name').prop('title') == accountName) {
-                  	accountMatch = true;
-                  	accountBalance = $(this).find('.user-data.currency').html();
-                  	accountBalance = Number(accountBalance.replace(/[^\d.-]/g, ''));
-                  }
-      
-               });
-      
-               if (accountMatch) {
-      
-               	if (accountBalance + categoryBalance !== 0) { // warn if funds do not balance to 0
-      
-               		var $thisCategoryBalance = $(this).find('.budget-table-cell-available-div .user-data.currency');
-      
-               		if ($thisCategoryBalance.hasClass('positive')) {
-               			$thisCategoryBalance.removeClass('positive').addClass('cautious');
-               		}
-      
-               	}
-               	
-               	accountMatch = false; // reset
-               } // account match
-               
-            });
-         
+
+    ynabToolKit.checkCreditBalances = new function ()  {
+
+      this.invoke = function() {
+        var debtPaymentCategories = $('.is-debt-payment-category.is-sub-category');
+        var accountName = {};
+        var accountBalance = {};
+        var accountMatch = {};
+
+        $(debtPaymentCategories).each(function() {
+          accountName = $(this).find('.budget-table-cell-name div.button-truncate').prop('title')
+
+          var categoryBalance = $(this).find('.budget-table-cell-available-div .user-data.currency').html();
+          categoryBalance = Number(categoryBalance.replace(/[^\d.-]/g, ''));
+
+          $('.nav-account-row').each(function() {
+
+            if ( $(this).find('.nav-account-name').prop('title') == accountName) {
+              accountMatch = true;
+              accountBalance = $(this).find('.user-data.currency').html();
+              accountBalance = Number(accountBalance.replace(/[^\d.-]/g, ''));
+            }
+
+          });
+
+          if (accountMatch) {
+            if (accountBalance + categoryBalance !== 0) { // warn if funds do not balance to 0
+             var $thisCategoryBalance = $(this).find('.budget-table-cell-available-div .user-data.currency');
+             if ($thisCategoryBalance.hasClass('positive')) {
+               $thisCategoryBalance.removeClass('positive').addClass('cautious');
+             }
+            }
+            accountMatch = false; // reset
+          }
+        });
+      },
+
+      this.observe = function(changedNodes) {
+
+        if (changedNodes.has('budget-inspector')) {
+          // The user has changed their budget row selection
+          ynabToolKit.checkCreditBalances.invoke();
+        }
       };
-      ynabToolKit.checkCreditBalances(); // Run itself once
-      
-   } else {
-   	setTimeout(poll, 250);
-   }		
+
+
+
+    };
+    ynabToolKit.checkCreditBalances.invoke(); // Run itself once
+
+  } else {
+   setTimeout(poll, 250);
+  }
 })();
 
 

--- a/src/common/res/features/goal-indicator/main.js
+++ b/src/common/res/features/goal-indicator/main.js
@@ -1,48 +1,58 @@
-(function poll() { 
+(function poll() {
   // Waits until an external function gives us the all clear that we can run (at /shared/main.js)
   if ( typeof ynabToolKit !== "undefined"  && ynabToolKit.pageReady === true ) {
-  
-    ynabToolKit.goalIndicator = function ()  { // Keep feature functions contained within this
-    	var entityManager = ynab.YNABSharedLib.defaultInstance.entityManager;
 
-    	function addIndicator (element, inticator) {
-    		var budgetedCell = $(element).find(".budget-table-cell-budgeted");
-    		if (budgetedCell.has(".goal-indicator").length == 0) {
-    			budgetedCell.prepend('<div class="goal-indicator">' + inticator + '</div>')
-    		}
-    	}
+    ynabToolKit.goalIndicator = new function ()  { // Keep feature functions contained within this
+      var entityManager = ynab.YNABSharedLib.defaultInstance.entityManager;
 
-    	function getCalculation(subCategoryName) {
-    		var crazyInternalId = "mcbc/" + ynabToolKit.shared.parseSelectedMonth().yyyymm() + "/" + entityManager.getSubCategoryByName(subCategoryName).getEntityId();
-			var calculation = entityManager.getMonthlySubCategoryBudgetCalculationById(crazyInternalId);
-			return calculation;
-    	}
+      function addIndicator (element, inticator) {
+        var budgetedCell = $(element).find(".budget-table-cell-budgeted");
+        if (budgetedCell.has(".goal-indicator").length == 0) {
+          budgetedCell.prepend('<div class="goal-indicator">' + inticator + '</div>')
+        }
+      }
 
-		var subCategories = $("ul.is-sub-category");
-		$(subCategories).each(function () {
-			var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
-			calculation = getCalculation(subCategoryName);
+      function getCalculation(subCategoryName) {
+        var crazyInternalId = "mcbc/" + ynabToolKit.shared.parseSelectedMonth().yyyymm() + "/" + entityManager.getSubCategoryByName(subCategoryName).getEntityId();
+      var calculation = entityManager.getMonthlySubCategoryBudgetCalculationById(crazyInternalId);
+      return calculation;
+      }
 
-			if (calculation.goalExpectedCompletion > 0) { 
-				// Target total goal
-				addIndicator(this, "T");
-			}
-			else if (calculation.goalTarget > 0) {
-				// Taget by date
-				// or Montly goal
-				addIndicator(this, "M");
-			}
-			else if (calculation.upcomingTransactions < 0) {
-				// Upcoming transactions "goal"
-				addIndicator(this, "U");
-			}
-		})
-     
+      this.invoke = function() {
+        var subCategories = $("ul.is-sub-category");
+        $(subCategories).each(function () {
+          var subCategoryName = $(this).find("li.budget-table-cell-name>div>div")[0].title;
+          calculation = getCalculation(subCategoryName);
+
+          if (calculation.goalExpectedCompletion > 0) {
+            // Target total goal
+            addIndicator(this, "T");
+          }
+          else if (calculation.goalTarget > 0) {
+            // Taget by date
+            // or Montly goal
+            addIndicator(this, "M");
+          }
+          else if (calculation.upcomingTransactions < 0) {
+            // Upcoming transactions "goal"
+            addIndicator(this, "U");
+          }
+        });
+      },
+
+      this.observe = function(changedNodes) {
+
+      if (changedNodes.has('navlink-budget') && changedNodes.has('active')) {
+          // The user has returned back to the budget screen
+          ynabToolKit.goalIndicator.invoke();
+        }
+      };
+
     }; // Keep feature functions contained within this
-    ynabToolKit.goalIndicator(); // Run once and activate setTimeOut()
+    ynabToolKit.goalIndicator.invoke(); // Run once and activate setTimeOut()
 
   } else {
-    setTimeout(poll, 250);  
+    setTimeout(poll, 250);
   }
 })();
 

--- a/src/common/res/features/highlight-negatives-negative/main.js
+++ b/src/common/res/features/highlight-negatives-negative/main.js
@@ -1,31 +1,41 @@
-	
-(function poll() {
-	if ( typeof ynabToolKit !== "undefined" && ynabToolKit.actOnChangeInit === true ) {
 
-		ynabToolKit.highlightNegativesNegative = function ()  {
-	   		
-			var availableBalances = $('.budget-table-cell-available-div.user-data');
-			var categoryBalance = {};
-	
-			$(availableBalances).each(function () {
-				categoryBalance = $(this).find('.user-data.currency').html(); // get the value
-			  	categoryBalance = Number( categoryBalance.replace(/[^\d.-]/g, '') ); // force data type as number
-			  	
-			
-				if ( categoryBalance < 0 ) {
-					
-				    if ( $(this).find('.user-data.currency').hasClass('cautious') ) {
-				    	$(this).find('.user-data.currency').removeClass('cautious').addClass('negative') 
-				    };
-				};
-	
-			});
-	
-		};
-		ynabToolKit.highlightNegativesNegative(); // call itself once
-		
-	} else {
-		setTimeout(poll, 250);
-	}		
+(function poll() {
+  if ( typeof ynabToolKit !== "undefined" && ynabToolKit.pageReady === true ) {
+
+    ynabToolKit.highlightNegativesNegative = new function ()  {
+
+      this.invoke = function() {
+        var availableBalances = $('.budget-table-cell-available-div.user-data');
+        var categoryBalance = {};
+
+        $(availableBalances).each(function () {
+          categoryBalance = $(this).find('.user-data.currency').html(); // get the value
+            categoryBalance = Number( categoryBalance.replace(/[^\d.-]/g, '') ); // force data type as number
+
+
+          if ( categoryBalance < 0 ) {
+
+              if ( $(this).find('.user-data.currency').hasClass('cautious') ) {
+                $(this).find('.user-data.currency').removeClass('cautious').addClass('negative')
+              };
+          };
+
+        });
+      },
+
+      this.observe = function(changedNodes) {
+
+        if (changedNodes.has('budget-inspector')) {
+          // The user has changed their budget row selection
+          ynabToolKit.highlightNegativesNegative.invoke();
+        }
+      };
+
+    };
+    ynabToolKit.highlightNegativesNegative.invoke(); // call itself once
+
+  } else {
+    setTimeout(poll, 250);
+  }
 })();
 

--- a/src/common/res/features/inspector-colours/main.js
+++ b/src/common/res/features/inspector-colours/main.js
@@ -1,23 +1,41 @@
 (function poll() {
   if ( typeof ynabToolKit !== "undefined" && ynabToolKit.actOnChangeInit === true ) {
 
-    ynabToolKit.updateInspectorColours = function ()  {
+    ynabToolKit.updateInspectorColours = new function ()  {
 
-      if ( !$('.budget-inspector-multiple').length ) {
+      this.invoke = function() {
+        if ( !$('.budget-inspector-multiple').length ) {
 
-        var selectedSubCat = $('.budget-table-row.is-sub-category.is-checked').find('.budget-table-cell-available-div span.currency')[0]
-        var inspectorAvailableText = $('.inspector-overview-available').find('dt');
-        var inspectorAvailableFunds = $('.inspector-overview-available').find('span');
-        if (!$(selectedSubCat).hasClass('positive')) {
-          $(inspectorAvailableText).attr("class", $(selectedSubCat).attr("class")).removeClass('currency');
+          var selectedSubCat = $('.budget-table-row.is-sub-category.is-checked')
+          .find('.budget-table-cell-available-div span.currency')[0]
+          var inspectorAvailableText = $('.inspector-overview-available').find('dt');
+          var inspectorAvailableFunds = $('.inspector-overview-available').find('span');
+          if (!$(selectedSubCat).hasClass('positive')) {
+            $(inspectorAvailableText).attr("class", $(selectedSubCat).attr("class")).removeClass('currency');
+          }
+          $(inspectorAvailableFunds).attr("class", $(selectedSubCat).attr("class"));
+
         }
-        $(inspectorAvailableFunds).attr("class", $(selectedSubCat).attr("class"));
+      },
 
-      }
+      this.observe = function(changedNodes) {
+
+        if (changedNodes.has('budget-table-cell-available-div')) {
+          // Changes are detected in the category balances
+          ynabToolKit.updateInspectorColours.invoke();
+        } else
+
+        if (ynabToolKit.changedNodes.has('is-sub-category') && ynabToolKit.changedNodes.has('is-checked')) {
+          // User has selected a specific sub-category
+          ynabToolKit.updateInspectorColours.invoke();
+        }
+
+      };
 
     };
-    
+    ynabToolKit.updateInspectorColours.invoke();
+
   } else {
     setTimeout(poll, 250);
-  }   
+  }
 })();

--- a/src/common/res/features/move-money-autocomplete/main.js
+++ b/src/common/res/features/move-money-autocomplete/main.js
@@ -2,9 +2,8 @@
 
 	if (typeof ynabToolKit !== "undefined" && ynabToolKit.pageReady === true) {
 
-
 		var originalentries = null;
-		ynabToolKit.moveMoneyAutocomplete = function() {
+		ynabToolKit.moveMoneyAutocomplete = new function() {
 
 			function autoCompleteApply() {
 
@@ -159,18 +158,27 @@
 				target.click();
 			}
 
-			var dialog = document.getElementsByClassName('ynab-select-options');
-			var label = document.getElementsByClassName('ynab-select-label');
-			var focus = document.getElementsByClassName('autocomplete-focus');
-			if (label.length > 0 && focus.length == 0) {
-				autoCompleteFocus();
-			}
-			if (dialog.length > 0) {
-				autoCompleteApply();
-			}
+			this.invoke = function() {
+				var dialog = document.getElementsByClassName('ynab-select-options');
+				var label = document.getElementsByClassName('ynab-select-label');
+				var focus = document.getElementsByClassName('autocomplete-focus');
+				if (label.length > 0 && focus.length == 0) {
+					autoCompleteFocus();
+				}
+				if (dialog.length > 0) {
+					autoCompleteApply();
+				}
+			},
+
+			this.observe = function(changedNodes) {
+
+      if (changedNodes.has('options-shown')) {
+          // We found a modal pop-up
+          ynabToolKit.moveMoneyAutocomplete.invoke();
+        }
+      };
 
 		};
-        ynabToolKit.moveMoneyAutocomplete(); // Activate itself
 
 	} else {
 		setTimeout(poll, 250);

--- a/src/common/res/features/remove-zero-categories/main.js
+++ b/src/common/res/features/remove-zero-categories/main.js
@@ -1,27 +1,39 @@
-	
+
 (function poll() {
-	
-	if ( typeof ynabToolKit !== "undefined" && ynabToolKit.actOnChangeInit === true) {
 
-		ynabToolKit.removeZeroCategories = function ()  {
-		    var coverOverbudgetingCategories = $( ".modal-budget-overspending .options-shown .ynab-select-options" ).children('li:not(:first-child)');
-		    coverOverbudgetingCategories.each(function(i) {
-		      var t = $(this).text(); // Category balance text.
-		      var categoryBalance = parseInt(t.substr(t.indexOf(":"), t.length).replace(/[^\d-]/g, ''));
-		      if ($(this).hasClass('is-selectable') && categoryBalance <= 0) {
-		        $(this).remove();
-		      }
-		    });
-		};
-		ynabToolKit.removeZeroCategories(); // Run itself once
-		
-	} else {
-		setTimeout(poll, 250);
-	}		
+  if ( typeof ynabToolKit !== "undefined" && ynabToolKit.pageReady === true) {
+
+    ynabToolKit.removeZeroCategories = new function ()  {
+
+      this.invoke = function() {
+        var coverOverbudgetingCategories = $( ".modal-budget-overspending .options-shown .ynab-select-options" ).children('li:not(:first-child)');
+        coverOverbudgetingCategories.each(function(i) {
+          var t = $(this).text(); // Category balance text.
+          var categoryBalance = parseInt(t.substr(t.indexOf(":"), t.length).replace(/[^\d-]/g, ''));
+          if ($(this).hasClass('is-selectable') && categoryBalance <= 0) {
+            $(this).remove();
+          }
+        });
+      },
+
+      this.observe = function(changedNodes) {
+
+      if (changedNodes.has('options-shown')) {
+          // We found a modal pop-up
+          ynabToolKit.removeZeroCategories.invoke();
+        }
+      };
+
+    };
+    ynabToolKit.removeZeroCategories.invoke(); // Run itself once
+
+  } else {
+    setTimeout(poll, 250);
+  }
 })();
-	
-	
-	
 
-	
-	    
+
+
+
+
+

--- a/src/common/res/features/resize-inspector/resize-inspector.js
+++ b/src/common/res/features/resize-inspector/resize-inspector.js
@@ -1,24 +1,36 @@
 (function poll() {
-   if ( typeof ynabToolKit !== 'undefined' && typeof $ !== 'undefined' && $('aside').length > 0 && $('section').length > 0 && ynabToolKit.actOnChangeInit) {
+   if ( typeof ynabToolKit !== 'undefined' && ynabToolKit.pageReady === true) {
 
-      ynabToolKit.resizeInspector = function ()  {
-        if($('.ember-view.content .budget-inspector').length > 0 ) {
-          if($('.resize-inspector').length == 0) {
-            $('.ember-view.content .scroll-wrap').addClass('resize-inspector');
-            $('aside').before('<div class="inspector-resize-handle">&nbsp;</div>');
-            $('.inspector-resize-handle').css('background-image','url('+window.resizeInspectorAsset+')');
-            $('section').resizable({
-              handleSelector: '.inspector-resize-handle',
-              resizeHeight: false
-            });
+      ynabToolKit.resizeInspector = new function ()  {
+
+        this.invoke = function() {
+          if( $('.ember-view.content .budget-inspector').length > 0 ) {
+            if($('.resize-inspector').length == 0) {
+              $('.ember-view.content .scroll-wrap').addClass('resize-inspector');
+              $('aside').before('<div class="inspector-resize-handle">&nbsp;</div>');
+              $('.inspector-resize-handle').css('background-image','url('+window.resizeInspectorAsset+')');
+              $('section').resizable({
+                handleSelector: '.inspector-resize-handle',
+                resizeHeight: false
+              });
+            }
+          } else {
+            $('.resize-inspector').removeClass('resize-inspector');
           }
-        } else {
-          $('.resize-inspector').removeClass('resize-inspector');
+        },
+
+        this.observe = function(changedNodes) {
+
+          if (changedNodes.has('layout')) {
+              // The user has switched screens
+              ynabToolKit.resizeInspector.invoke();
+          }
         }
+
       };
 
-      ynabToolKit.resizeInspector(); // Run itself once
+      ynabToolKit.resizeInspector.invoke(); // Run itself once
    } else {
      setTimeout(poll, 250);
-   }    
+   }
 })();

--- a/src/common/res/features/shared/example.js
+++ b/src/common/res/features/shared/example.js
@@ -1,40 +1,52 @@
   /**
-   * To help isolate and protect our functions and variables from 
-   * the production code, we want to contain all of our optional features
-   * within the global ynabToolKit object, which is created by /shared/main.js
-   * 
-   * We are working to refactor our existing feature scripts to be contained
-   * within the ynabToolKit object. We are also working on moving away from
-   * depending on setTimeOut to handle changes to the page. When that's done, 
-   * this example document will be updated.
-   * 
-   * In the meanimte, you can use the following example in your own main.js file
-   * and adapt it as needed. Replace 'awesomeFeature' etc with your own names.
-   **/
+  * Use this template to add new js functions to your features
+  *
+  * To help isolate and protect our functions and variables from
+  * the production code, we want to contain all of our optional features
+  * within the global ynabToolKit object, which is created on page load.
+  *
+  * Note: Using this.observe() is optional, but we use a MutationObserver instance
+  * to evaluate changes on the page and feed those changes to each function
+  * that might want to act on a specific change in the DOM.
+  *
+  * If the python build file doesn't yet build it automatically, make sure there
+  * is an entry in /shared/feedChanges.js to ensure the changedNodes are published
+  * to your script:
+  *
+  * try {
+  *       ynabToolKit.awesomeFeature.observe(changedNodes);
+  *     } catch(err) { } // ignore failures
+  */
 
 
-(function poll() { 
+(function poll() {
   // Waits until an external function gives us the all clear that we can run (at /shared/main.js)
   if ( typeof ynabToolKit !== "undefined"  && ynabToolKit.pageReady === true ) {
-  
-    ynabToolKit.awesomeFeature = function ()  { // Keep feature functions contained within this
 
+    ynabToolKit.awesomeFeature = new function ()  {
 
-      awesomeFunction() {
-        // Do awesome things
-      };
+      // Supporting functions,
+      // or variables, etc
 
-      setUpAwesome () {
-        // Maybe some other awesome things
-      };
+      this.invoke = function() {
+        // Code you expect to run each time your feature needs to update or modify YNAB's state
+      },
 
+      this.observe = function(changedNodes) {
 
-      setTimeout(setUpAwesome, 250); // We are working on deprecating the need for this soon
+        if ( changedNodes.has('class-name-of-interest') ) {
+          ynabToolKit.awesomeFeature.invoke();
+          // Call this.invoke() to activate your function if you find any class names
+          // in the set of changed nodes that indicates your function need may need to run.
+        }
 
-    }; // Keep feature functions contained within this
-    ynabToolKit.awesomeFeature(); // Run once and activate setTimeOut()
+      }
+
+    }; // Keep feature functions contained within this object
+
+    ynabToolKit.awesomeFeature.invoke(); // Run your script once on page load
 
   } else {
-    setTimeout(poll, 250);  
+    setTimeout(poll, 250);
   }
 })();

--- a/src/common/res/features/shared/feedChanges.js
+++ b/src/common/res/features/shared/feedChanges.js
@@ -22,6 +22,42 @@
         ynabToolKit.toggleSplits.observe(changedNodes);
       } catch(err) {/* ignore */}
 
+      try {
+        ynabToolKit.updateInspectorColours.observe(changedNodes);
+      } catch(err) {/* ignore */}
+
+      try {
+        ynabToolKit.resizeInspector.observe(changedNodes);
+      } catch(err) {/* ignore */}
+
+      try {
+        ynabToolKit.budgetProgressBars.observe(changedNodes);
+      } catch(err) {/* ignore */}
+
+      try {
+        ynabToolKit.goalIndicator.observe(changedNodes);
+      } catch(err) {/* ignore */}
+
+      try {
+        ynabToolKit.warnOnQuickBudget.observe(changedNodes);
+      } catch(err) {/* ignore */}
+
+      try {
+        ynabToolKit.removeZeroCategories.observe(changedNodes);
+      } catch(err) {/* ignore */}
+
+      try {
+        ynabToolKit.moveMoneyAutocomplete.observe(changedNodes);
+      } catch(err) {/* ignore */}
+
+      try {
+        ynabToolKit.highlightNegativesNegative.observe(changedNodes);
+      } catch(err) {/* ignore */}
+
+      try {
+        ynabToolKit.checkCreditBalances.observe(changedNodes);
+      } catch(err) {/* ignore */}
+
     };
 
   } else {

--- a/src/common/res/features/shared/feedChanges.js
+++ b/src/common/res/features/shared/feedChanges.js
@@ -7,15 +7,20 @@
       // Python script auto builds up this list of features
       // that will use the mutation observer from actOnChange()
 
-      if ( ynabToolKit.swapClearedFlagged ){
+      // If a feature doesn't need to use observe(), we
+      // just let it fail silently
+
+      try {
         ynabToolKit.swapClearedFlagged.observe(changedNodes);
-      }
-      if ( ynabToolKit.insertPacingColumns ){
+      } catch(err) {/* ignore */}
+
+      try {
         ynabToolKit.insertPacingColumns.observe(changedNodes);
-      }
-      if ( ynabToolKit.toggleSplits ){
+      } catch(err) {/* ignore */}
+
+      try {
         ynabToolKit.toggleSplits.observe(changedNodes);
-      }
+      } catch(err) {/* ignore */}
 
     };
 

--- a/src/common/res/features/warn-on-quick-budget/main.js
+++ b/src/common/res/features/warn-on-quick-budget/main.js
@@ -1,45 +1,62 @@
 (function poll() {
 
-	if (typeof ynabToolKit !== "undefined" && ynabToolKit.actOnChangeInit === true) {
+  if (typeof ynabToolKit !== "undefined" && ynabToolKit.actOnChangeInit === true) {
 
-		ynabToolKit.warnOnQuickBudget = function() {
-            var buttons = document.getElementsByClassName('budget-inspector-button');
-            for (var i = 0; i < buttons.length; i++) {
-                button = buttons[i];
-                button.onclick = function(event) {
-                    var e = event || window.event;
-                    var parent = $(button).parent().parent().parent();
-                    if ($(parent).hasClass('budget-inspector-default')) { // No row selected
-                        var budgetRows = $('.budget-table-cell-budgeted');
-                        var accepted = false;
-                        budgetRows.each(function(index, el) {
-                            if ($(el).find('span.user-data').length > 0) {
-                                if (!$($(el).find('span.user-data')[0]).hasClass('zero')) { // Something was budgeted
-                                if (!confirm('Are you sure you want to replace previously budgeted values?')) {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    return false;
-                                } else {
-                                    return false;
-                                }
-                            }
-                        }
-                        });
-                    } else if ($(parent).hasClass('budget-inspector')) { // Row selected
-                        if (!$($(parent).find('.budget-inspector-category-overview').find('span.user-data')[1]).hasClass('zero')) { // Something was budgeted
-                            if (!confirm('Are you sure you want to replace previously budgeted value?')) {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                return false;
-                            }
-                        }
-                    }
+    ynabToolKit.warnOnQuickBudget = new function() {
+
+      this.invoke = function() {
+        var buttons = document.getElementsByClassName('budget-inspector-button');
+        for (var i = 0; i < buttons.length; i++) {
+          button = buttons[i];
+          button.onclick = function(event) {
+            var e = event || window.event;
+            var parent = $(button).parent().parent().parent();
+            if ($(parent).hasClass('budget-inspector-default')) { // No row selected
+              var budgetRows = $('.budget-table-cell-budgeted');
+              var accepted = false;
+              budgetRows.each(function(index, el) {
+                if ($(el).find('span.user-data').length > 0) {
+                  if (!$($(el).find('span.user-data')[0]).hasClass('zero')) { // Something was budgeted
+                  if (!confirm('Are you sure you want to replace previously budgeted values?')) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    return false;
+                  } else {
+                    return false;
+                  }
                 }
+              }
+              });
+            } else if ($(parent).hasClass('budget-inspector')) { // Row selected
+              if (!$($(parent).find('.budget-inspector-category-overview').find('span.user-data')[1]).hasClass('zero')) { // Something was budgeted
+                if (!confirm('Are you sure you want to replace previously budgeted value?')) {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  return false;
+                }
+              }
             }
-		};
-        ynabToolKit.warnOnQuickBudget(); // Activate itself
+          }
+        }
+      },
 
-	} else {
-		setTimeout(poll, 250);
-	}
+      this.observe = function(changedNodes) {
+
+      if (changedNodes.has('navlink-budget') && changedNodes.has('active')) {
+          // The user has returned back to the budget screen
+          ynabToolKit.warnOnQuickBudget.invoke();
+        } else
+
+        // The user has changed their budget row selection
+        if (changedNodes.has('budget-inspector')) {
+          ynabToolKit.warnOnQuickBudget.invoke();
+        }
+      };
+
+    }; // Keep feature functions contained within this
+    ynabToolKit.warnOnQuickBudget.invoke();
+
+  } else {
+    setTimeout(poll, 250);
+  }
 })();


### PR DESCRIPTION
Here we go. Starting with ( 780841a ), I have updated the example.js to use the new pattern introduced by this refactor. In the short term, new feature development that need to use MutationObserver will need to have a manual entry in feedChanges.js (until the design for that python script is deployed). I have done so for each of the features that use to have conditionals within actOnChange itself.

My text editor has made plenty of line changes to each of the files it touches, so you may want to review the changes with ?w=1 or the respective option in your git tooling.

The total list of affected features is (based on the prebuilt feedChanges.js file)
- updateInspectorColours
- insertPacingColumns
- toggleSplits
- updateInspectorColours
- resizeInspector
- budgetProgressBars
- goalIndicator
- warnOnQuickBudget
- removeZeroCategories
- moveMoneyAutocomplete
- highlightNegativesNegative
- checkCreditBalances

*Plus these already present*
- toggleSplits
- insertPacingColumns
- swapClearedFlagged

Each feature can be updated and modified to use different conditionals on the ynabToolKit.changedNodes object without impacting other unrelated features.

There are still a couple of other feature files that may need to be updated in order to be within the ynabToolKit object at all, but I'll refactor those into this new pattern once this is merged in.

Each of these has been tested in Chrome but let me know if anything unusual comes up.
