### PR TITLE
Correction for pull 147

### DIFF
--- a/src/common/res/features/reconciled-text-color/main.js
+++ b/src/common/res/features/reconciled-text-color/main.js
@@ -1,22 +1,40 @@
-(function addIsReconciledClassForRows() {
-   
-  if ( typeof Em !== 'undefined' && typeof Ember !== 'undefined' && typeof $ !== 'undefined' ) {
-    
-    var transactionRows = $('.ynab-grid-body-row');
-    var previousReconciled = false;
-    $(transactionRows).each(function(i) {
-      clearedField = $(this).find(".ynab-grid-cell-cleared>i").first();
-      isReconciled = clearedField.hasClass("is-reconciled");
-      if (isReconciled) {
-        $(this).addClass("is-reconciled-row");
-      }
-      if ($(this).hasClass("ynab-grid-body-sub") && previousReconciled) {
-        $(this).addClass("is-reconciled-row");
-        isReconciled = true;
-      }
-      previousReconciled = isReconciled;
-    })
-  }
-  setTimeout(addIsReconciledClassForRows, 300);
+(function poll() {
+  // Waits until an external function gives us the all clear that we can run (at /shared/main.js)
+  if ( typeof ynabToolKit !== "undefined"  && ynabToolKit.pageReady === true ) {
 
+    ynabToolKit.reconciledTextColor = new function ()  { // Keep feature functions contained within this
+
+      this.invoke = function() {
+
+        var transactionRows = $('.ynab-grid-body-row');
+        var previousReconciled = false;
+        $(transactionRows).each(function(i) {
+          clearedField = $(this).find(".ynab-grid-cell-cleared>i").first();
+          isReconciled = clearedField.hasClass("is-reconciled");
+          if (isReconciled) {
+            $(this).addClass("is-reconciled-row");
+          }
+          if ($(this).hasClass("ynab-grid-body-sub") && previousReconciled) {
+            $(this).addClass("is-reconciled-row");
+            isReconciled = true;
+          }
+          previousReconciled = isReconciled;
+        })
+      },
+
+      this.observe = function(changedNodes) {
+
+        if (changedNodes.has('ynab-grid-body')) {
+          // We found Account transactions rows
+          ynabToolKit.reconciledTextColor.invoke();
+        }
+
+      };
+
+    }; // Keep feature functions contained within this
+    ynabToolKit.reconciledTextColor.invoke(); // run once on page load
+
+  } else {
+    setTimeout(poll, 250);
+  }
 })();

--- a/src/common/res/features/reconciled-text-color/settings.json
+++ b/src/common/res/features/reconciled-text-color/settings.json
@@ -13,9 +13,21 @@
                     { "name": "Dark gray with green background", "value": "4", "style": "color: #8e9fb0; background-color: #e7faeb" }
                  ],
       "actions": {
-                    "1": [ "injectCSS", "green.css" ],
-                    "2": [ "injectCSS", "lightgray.css" ],
-                    "3": [ "injectCSS", "darkgray.css" ],
-                    "4": [ "injectCSS", "chance.css" ]
+                    "1": [
+                      "injectCSS", "green.css",
+                      "injectScript", "main.js"
+                    ],
+                    "2": [
+                      "injectCSS", "lightgray.css",
+                      "injectScript", "main.js"
+                    ],
+                    "3": [
+                      "injectScript", "main.js",
+                      "injectCSS", "darkgray.css"
+                    ],
+                    "4": [
+                      "injectCSS", "chance.css",
+                      "injectScript", "main.js"
+                    ]
                  }
 }

--- a/src/common/res/features/reconciled-text-color/settings.json
+++ b/src/common/res/features/reconciled-text-color/settings.json
@@ -13,21 +13,9 @@
                     { "name": "Dark gray with green background", "value": "4", "style": "color: #8e9fb0; background-color: #e7faeb" }
                  ],
       "actions": {
-                    "1": [
-                      "injectCSS", "green.css",
-                      "injectScript", "main.js"
-                    ],
-                    "2": [
-                      "injectCSS", "lightgray.css",
-                      "injectScript", "main.js"
-                    ],
-                    "3": [
-                      "injectScript", "main.js",
-                      "injectCSS", "darkgray.css"
-                    ],
-                    "4": [
-                      "injectCSS", "chance.css",
-                      "injectScript", "main.js"
-                    ]
+                    "1": [ "injectCSS", "green.css" ],
+                    "2": [ "injectCSS", "lightgray.css" ],
+                    "3": [ "injectCSS", "darkgray.css" ],
+                    "4": [ "injectCSS", "chance.css" ]
                  }
 }

--- a/src/common/res/features/toggle-splits/settings.json
+++ b/src/common/res/features/toggle-splits/settings.json
@@ -1,6 +1,7 @@
 {
          "name": "toggleSplits",
          "type": "checkbox",
+       "hidden": "true",
       "default": false,
       "section": "accounts",
         "title": "Add a Toggle Splits Button",

--- a/src/common/res/features/toggle-splits/settings.json
+++ b/src/common/res/features/toggle-splits/settings.json
@@ -1,7 +1,6 @@
 {
          "name": "toggleSplits",
          "type": "checkbox",
-       "hidden": "true",
       "default": false,
       "section": "accounts",
         "title": "Add a Toggle Splits Button",


### PR DESCRIPTION
I botched up #147 and mixed in a setting to hide the toggle split feature, while not actually including the refactor for the reconciled text color feature as described.

This reverts the commit from #147 (8def128) and introduces two new commits with the correct contents in each. Specifically:

- A single commit for removing the toggle split option
- A new commit that includes the important update for reconciled-text-color/main.js