### PR TITLE
Remove mutation nodes classes splitting

### DIFF
--- a/src/common/res/features/act-on-change/main.js
+++ b/src/common/res/features/act-on-change/main.js
@@ -39,14 +39,15 @@
               ynabToolKit.debugNodes.errors = err
             }
 
-            ynabToolKit.changedNodes = new Set([...ynabToolKit.changedNodes, ...nodeClasses]);
+            ynabToolKit.changedNodes.add($node[0].className.replace(/^ember-view /,''));
 
           }); // each node mutation event
 
         }); // each mutation event
 
         if (ynabToolKit.debugNodes) {
-          console.log('###')
+          console.log(ynabToolKit.changedNodes);
+          console.log('###');
         }
 
         // Now we are ready to feed the change digest to the


### PR DESCRIPTION
This is a suggestion improvement. It makes possible to write
`changedNodes.has('navlink-budget active')`
instead of
`changedNodes.has('navlink-budget') && changedNodes.has('active')`

This is better because now the second expression equals true when we go from Budget to Accounts.

I didn't check features observer methods. Some errors may appear.