### PR TITLE
Fix category hover issue of Move Money Dialog

### DIFF
--- a/src/common/res/features/move-money-dialog/main.css
+++ b/src/common/res/features/move-money-dialog/main.css
@@ -5,7 +5,6 @@
 
 .ynab-select-options {
     height: 20em;
-    top: -86px;
 }
 
 .modal-budget-move-money .modal-actions {


### PR DESCRIPTION
Fixes #165

I didn't build and test the full extension, but I did test that removing this line in chrome dev tools fixed the issue. Didn't test in other browsers. Let me know if you need any more testing in other browsers.