### PR TITLE
Add min-height to #wrapper id to make dark mode better

### DIFF
--- a/src/common/assets/dream-admin-theme/css/custom-styles.css
+++ b/src/common/assets/dream-admin-theme/css/custom-styles.css
@@ -14,6 +14,7 @@ body {
 
  #wrapper {
     width: 100%;
+    min-height: 100vh;
     background-color: white;
 }
 


### PR DESCRIPTION
If the body is too short for the window, dark mode doesn't cover the bottom, because #wrapper is too short:

![toolkit for ynab options - chromium_010](https://cloud.githubusercontent.com/assets/1148665/12890368/f443acc2-ce48-11e5-89dd-4fda8f9d12b1.png)

Adding
min-height: 100vh; to the #wrapper id fixes this.

http://caniuse.com/#feat=viewport-units