### PR TITLE
Fixes several bugs in move money dialog search

### DIFF
--- a/src/common/res/features/move-money-autocomplete/main.js
+++ b/src/common/res/features/move-money-autocomplete/main.js
@@ -85,15 +85,6 @@
 				setTimeout(autoCompleteRemoved, 250);
 			}
 
-			function autoCompleteFocus() {
-				var selectLabel = document
-						.getElementsByClassName("ynab-select")[0];
-				selectLabel.className += " autocomplete-focus";
-				selectLabel.onfocus = function(event) {
-					event.target.click();
-				}
-			}
-
 			function autoCompleteHandleKeyPress(oldVal, newVal) {
 				var components = document
 						.getElementsByClassName('ynab-select-options');
@@ -147,24 +138,16 @@
 					var selectLabel = document
 							.getElementsByClassName("ynab-select-label")[0];
 					if (selectLabel != undefined) {
-						selectLabel.className = "ynab-select-label";
+						$(selectLabel).removeClass('autocomplete-override');
 					}
+					originalentries = null;
 				} else {
 					setTimeout(autoCompleteRemoved, 250);
 				}
 			}
 
-			function autoCompleteSelectOption(target) {
-				target.click();
-			}
-
 			this.invoke = function() {
 				var dialog = document.getElementsByClassName('ynab-select-options');
-				var label = document.getElementsByClassName('ynab-select-label');
-				var focus = document.getElementsByClassName('autocomplete-focus');
-				if (label.length > 0 && focus.length == 0) {
-					autoCompleteFocus();
-				}
 				if (dialog.length > 0) {
 					autoCompleteApply();
 				}


### PR DESCRIPTION
Fixes a couple of bugs I found when playing with the move money search dialog. Please let me know if some of these aren't bugs or if I deleted something I shouldn't have in the code.

### Bug 1
1. Type something in
2. Backspace
3. Type it again
4. Two of the same item appears

<img width="327" alt="duplicateentries" src="https://cloud.githubusercontent.com/assets/2659793/12923910/6fa62b56-cf0c-11e5-905f-85885ae352c0.png">

### Bug 2
1. Click search dropdown
2. Click out
3. Click search dropdown again
4. Search does not reappear

<img width="306" alt="searchdisappears" src="https://cloud.githubusercontent.com/assets/2659793/12923966/a84b1da4-cf0c-11e5-944c-51a8b661d75c.png">

### Bug 3
1. Open the move money search dialog and use the search feature.
2. Close out
3. Add a new category to the budget
4. Open the move money dialog again
5. Search for an item (but not the one you added)
6. Backspace and search for the item you added
6. The item cannot be found

Bug 3 was fixed by nulling out the `originalentries` variable that was previously only set once the first time that the move money dialog is loaded. This variable is used as the base list of options to filter and populate the dropdown as the user searches. Keeping a hold of the options only once was causing the data to be stale if you add new categories and probably remove them but I didn't test that.