### PR TITLE
Don't add another reports panel if it exists already

### DIFF
--- a/src/common/res/features/reports/main.js
+++ b/src/common/res/features/reports/main.js
@@ -193,6 +193,12 @@
 
         // Remove the content and put our report there instead.
         this.showReports = function() {
+
+          // Don't add another report if it already exists
+          if ($('#reports-panel').length) {
+            return;
+          }
+
           // Update the nav
           $('.navlink-budget, .navlink-accounts').removeClass('active');
           $('.nav-account-row').removeClass('is-selected');


### PR DESCRIPTION
Click the reports button keeps adding reports panels. Don't add a reports panel if one already exists.