### PR TITLE
Printing Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is what the extension can do for you:
 - Export all transactions from the current budget in CSV format.
 - Colour Blind Mode - Changes colours of some of the numbers to make the interface easier on people with certain visual disabilities.
 - Make the calculator work like YNAB4. When you press + or - (etc) the calculator moves to the end of the line so your number isn't lost.
-- Printing Improvements: Now when you print your budget it looks good!
+- Printing Improvements: Now when you print your budget or account it looks good!
 - Add a budget category to zero button in the inspector.
 - Hide the Age of Money calculation.
 - Collapse left navigation bar for more screen room

--- a/src/common/res/features/printing-improvements/main.css
+++ b/src/common/res/features/printing-improvements/main.css
@@ -43,7 +43,10 @@
 		min-width: 0;
 		height: auto;
 	}
-	
+	body .budget-table-row {
+		page-break-inside: avoid;
+	}
+		
 	body .budget-table-header .budget-table-cell-checkbox, 
 	body .budget-table-row .budget-table-cell-checkbox,
 	body .budget-table-header .budget-table-cell-status, 
@@ -68,9 +71,9 @@
 	}
 	
 	body .budget-table-row.is-master-category {
-	   border-top: 2px solid #ccc;
-	   background: transparent;
-	   margin-top: 20px;
+		border-top: 2px solid #ccc;
+		background: transparent;
+		margin-top: 20px;
 		height: 2.1em;
 	}
 	body .budget-table-row.is-master-category .budget-table-cell-name .budget-table-cell-name-row-label-item {
@@ -175,8 +178,11 @@
 		display: none;
 	}
 	
-	.ynab-grid-body-row {
-		height: 26px;
+	.ynab-grid-body-row,
+	.ynab-grid-body-row-top,
+	.ynab-grid-body-row-bottom {
+		height: 26px !important;
+		page-break-inside: avoid;
 	}
 	.ynab-grid-cell {
 	    padding: .2em 0;

--- a/src/common/res/features/printing-improvements/settings.json
+++ b/src/common/res/features/printing-improvements/settings.json
@@ -4,7 +4,7 @@
       "default": true,
       "section": "general",
         "title": "Printing Improvements",
-  "description": "Changes print styles so budget and account sections can be easily printed. Due to the number of columns, tha account section should be printed using landscape orientation.",
+  "description": "Changes print styles so budget and account sections can be easily printed. Due to the number of columns, the account section should be printed using landscape orientation.",
       "actions": {
                     "true": [
                       "injectCSS", "main.css"


### PR DESCRIPTION
Fixed the issue where budget rows could be getting cut off when
printing, and did some additional improvements to fix blank space when
printing the account section.

I did discover, though, that the account view only prints about a page
and a half of transactions due to the way Ember hides and loads
transaction data when scrolling. That may be a limitation I can’t do
much about without some extensive work. I’ll look into it.